### PR TITLE
[BUG] close #52

### DIFF
--- a/cmd/use.go
+++ b/cmd/use.go
@@ -123,7 +123,11 @@ func findMustGatherIn(path string) (string, error) {
 		return path, fmt.Errorf("Expected one directory in path: \"%s\", found: %s.", path, strconv.Itoa(numDirs))
 	}
 	if !timeStampFound && numDirs == 1 {
-		retPath, retErr = findMustGatherIn(path + "/" + dirName)
+		return findMustGatherIn(path + "/" + dirName)
+	}
+	if !timeStampFound && !namespacesFolderFound {
+		// Case: "path" is an empty directory
+		return path, fmt.Errorf("wrong must-gather file composition for %v", path)
 	}
 
 	return retPath + "/", retErr


### PR DESCRIPTION
I've tried the following patterns and it seems to be working correctly: any feedback is appreciated.

**Expected success:**


**Case 1 (direct must-gather)**
```
 $ ls  -l <must-gather-dir>
cluster-scoped-resources
etcd_info
event-filter.html
host_service_logs
ingress_controllers
insights-data
monitoring
namespaces
network_logs
static-pods
timestamp
version
web_hooks

 $ omc use <must-gather-dir>
 $ echo $?
0
 ```

**Case 2 (nested-folder with timestamp file)**
```
 $ ls -l <dir>
event-filter.html
must-gather-dir
timestamp
 
 $ ls  -l <dir/must-gather-dir>
cluster-scoped-resources
etcd_info
event-filter.html
host_service_logs
ingress_controllers
insights-data
monitoring
namespaces
network_logs
static-pods
timestamp
version
web_hooks

 $ omc use <dir>
 $ echo $?
0
 ```

**Case 3 (nested-nested-folder with timestamp file)**
```
 $ ls  -l <parent>
child
 
 $ ls -l <parent/child>
event-filter.html
must-gather-dir
timestamp
 
 $ ls  -l <parent/child/must-gather-dir>
cluster-scoped-resources
etcd_info
event-filter.html
host_service_logs
ingress_controllers
insights-data
monitoring
namespaces
network_logs
static-pods
timestamp
version
web_hooks

 $ omc use <parent>
 $ echo $?
0
 ```

**Expected failures:**

**Case 4 (Empty folder)**
```
 $ ls  <empty-folder>
 
 $ omc use <empty-dir>
wrong must-gather file composition for <empty-dir-path>
 $ echo $?
1
```

**Case 5 (Folder with more than one directory and a timestamp file)**
```
 $ cd <dir>
 $ ls -d */
folder1/ folder2/
 $ ls -l <dir>
folder1
folder2
timestamp

 $ omc use <dir>
Expected one directory in path: "<dir-with-timestmap-file-and-two-dirs-path>", found: 2
 $ echo $?
1
```

**Case 6 (Non existing folder)**
```
 $ ls <non-existing-path>
 ls: cannot access <non-existing-path>: No such file or directory
 
  $ omc use <non-existing-path>
"Error: <non-existing-path> is not a directory"
  $ echo $?
 1
```

**Case 7 (File)**
```
  $ touch <file>
  $ omc use <file>
 Error: <file-path> is not a dirctory
  $ echo $?
 1
```
