### PR TITLE
[WIP] add cert inspection command

### DIFF
--- a/cmd/certs/certs.go
+++ b/cmd/certs/certs.go
@@ -1,0 +1,37 @@
+/*
+Copyright © 2023 Bram Verschueren <bverschueren@redhat.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package certs
+
+import (
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var Certs = &cobra.Command{
+	Use: "certs",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+		os.Exit(0)
+	},
+}
+
+func init() {
+	Certs.AddCommand(
+		Inspect,
+	)
+	Certs.PersistentFlags().BoolVarP(&vars.AllNamespaceBoolVar, "all-namespaces", "A", false, "If present, list the requested object(s) across all namespaces.")
+}

--- a/cmd/certs/inspect.go
+++ b/cmd/certs/inspect.go
@@ -1,0 +1,214 @@
+/*
+Copyright © 2023 Bram Verschueren <bverschueren@redhat.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"github.com/gmeghnag/omc/cmd/get/certificate"
+	"github.com/gmeghnag/omc/cmd/get/core"
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+	"io"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/cert"
+	"os"
+	"strings"
+)
+
+var Inspect = &cobra.Command{
+	Use:   "inspect",
+	Short: "certificate inspect",
+	Run: func(cmd *cobra.Command, args []string) {
+		resourceTypes := []string{"cm", "secret", "csr"}
+		if len(args) == 1 {
+			resourceTypes = strings.Split(strings.ToLower(args[0]), ",")
+		}
+		inspectResources(resourceTypes)
+	},
+}
+
+func inspectResources(resourceTypes []string) {
+	for _, resourceType := range resourceTypes {
+		switch resourceType {
+		case "cm", "configmap", "configmaps":
+			var configmaps []*corev1.ConfigMap
+			core.GetConfigMaps(vars.MustGatherRootPath, vars.Namespace, "", vars.AllNamespaceBoolVar, &configmaps)
+			for _, r := range configmaps {
+				if err := certInspect(r); err != nil {
+					fmt.Println(err)
+				}
+			}
+		case "secret", "secrets":
+			var secrets []*corev1.Secret
+			core.GetSecrets(vars.MustGatherRootPath, vars.Namespace, "", vars.AllNamespaceBoolVar, &secrets)
+			for _, r := range secrets {
+				if err := certInspect(r); err != nil {
+					fmt.Println(err)
+				}
+			}
+		case "csr", "certificatesigningrequest", "certificatesigningrequests":
+			var csrs []certificatesv1.CertificateSigningRequest
+			certificate.GetCertificateSigningRequests(vars.MustGatherRootPath, vars.Namespace, "", vars.AllNamespaceBoolVar, &csrs)
+			for _, r := range csrs {
+				if err := certInspect(r); err != nil {
+					fmt.Println(err)
+				}
+			}
+		}
+	}
+}
+
+func certInspect(resource interface{}) error {
+	switch castObj := resource.(type) {
+	case *corev1.ConfigMap:
+		inspectConfigMap(os.Stdout, castObj)
+	case *corev1.Secret:
+		inspectSecret(os.Stdout, castObj)
+	case *certificatesv1.CertificateSigningRequest:
+		inspectCSR(os.Stdout, castObj)
+	default:
+		return fmt.Errorf("unhandled resource: %T", castObj)
+	}
+	return nil
+}
+
+func inspectConfigMap(w io.Writer, obj *corev1.ConfigMap) {
+	resourceString := fmt.Sprintf("configmaps/%s[%s]", obj.Name, obj.Namespace)
+	caBundle, ok := obj.Data["ca-bundle.crt"]
+	if !ok {
+		fmt.Fprintf(w, "%s NOT a ca-bundle\n", resourceString)
+		return
+	}
+	if len(caBundle) == 0 {
+		fmt.Fprintf(w, "%s MISSING ca-bundle content\n", resourceString)
+		return
+	}
+
+	fmt.Fprintf(w, "%s - ca-bundle (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+	certificates, err := cert.ParseCertsPEM([]byte(caBundle))
+	if err != nil {
+		fmt.Fprintf(w, "    ERROR - %v\n", err)
+		return
+	}
+	for _, curr := range certificates {
+		fmt.Fprintf(w, "    %s\n", certDetail(curr))
+	}
+}
+
+func inspectSecret(w io.Writer, obj *corev1.Secret) {
+	resourceString := fmt.Sprintf("secrets/%s[%s]", obj.Name, obj.Namespace)
+	tlsCrt, isTLS := obj.Data["tls.crt"]
+	if isTLS {
+		fmt.Fprintf(w, "%s - tls (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+		if len(tlsCrt) == 0 {
+			fmt.Fprintf(w, "%s MISSING tls.crt content\n", resourceString)
+			return
+		}
+
+		certificates, err := cert.ParseCertsPEM([]byte(tlsCrt))
+		if err != nil {
+			fmt.Fprintf(w, "    ERROR - %v\n", err)
+			return
+		}
+		for _, curr := range certificates {
+			fmt.Fprintf(w, "    %s\n", certDetail(curr))
+		}
+	}
+
+	caBundle, isCA := obj.Data["ca.crt"]
+	if isCA {
+		fmt.Fprintf(w, "%s - token secret (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+		if len(caBundle) == 0 {
+			fmt.Fprintf(w, "%s MISSING ca.crt content\n", resourceString)
+			return
+		}
+
+		certificates, err := cert.ParseCertsPEM([]byte(caBundle))
+		if err != nil {
+			fmt.Fprintf(w, "    ERROR - %v\n", err)
+			return
+		}
+		for _, curr := range certificates {
+			fmt.Fprintf(w, "    %s\n", certDetail(curr))
+		}
+	}
+
+	if !isTLS && !isCA {
+		fmt.Fprintf(w, "%s NOT a tls secret or token secret\n", resourceString)
+		return
+	}
+}
+
+func inspectCSR(w io.Writer, obj *certificatesv1.CertificateSigningRequest) {
+	resourceString := fmt.Sprintf("csr/%s", obj.Name)
+	if len(obj.Status.Certificate) == 0 {
+		fmt.Fprintf(w, "%s NOT SIGNED\n", resourceString)
+		return
+	}
+
+	fmt.Fprintf(w, "%s - (%v)\n", resourceString, obj.CreationTimestamp.UTC())
+	certificates, err := cert.ParseCertsPEM([]byte(obj.Status.Certificate))
+	if err != nil {
+		fmt.Fprintf(w, "    ERROR - %v\n", err)
+		return
+	}
+	for _, curr := range certificates {
+		fmt.Fprintf(w, "    %s\n", certDetail(curr))
+	}
+}
+
+func certDetail(certificate *x509.Certificate) string {
+	humanName := certificate.Subject.CommonName
+	signerHumanName := certificate.Issuer.CommonName
+	if certificate.Subject.CommonName == certificate.Issuer.CommonName {
+		signerHumanName = "<self>"
+	}
+
+	usages := []string{}
+	for _, curr := range certificate.ExtKeyUsage {
+		if curr == x509.ExtKeyUsageClientAuth {
+			usages = append(usages, "client")
+			continue
+		}
+		if curr == x509.ExtKeyUsageServerAuth {
+			usages = append(usages, "serving")
+			continue
+		}
+
+		usages = append(usages, fmt.Sprintf("%d", curr))
+	}
+
+	validServingNames := []string{}
+	for _, ip := range certificate.IPAddresses {
+		validServingNames = append(validServingNames, ip.String())
+	}
+	for _, dnsName := range certificate.DNSNames {
+		validServingNames = append(validServingNames, dnsName)
+	}
+	servingString := ""
+	if len(validServingNames) > 0 {
+		servingString = fmt.Sprintf(" validServingFor=[%s]", strings.Join(validServingNames, ","))
+	}
+
+	groupString := ""
+	if len(certificate.Subject.Organization) > 0 {
+		groupString = fmt.Sprintf(" groups=[%s]", strings.Join(certificate.Subject.Organization, ","))
+	}
+
+	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v)", humanName, strings.Join(usages, ","), groupString, servingString, signerHumanName, certificate.NotBefore.UTC(), certificate.NotAfter.UTC())
+}

--- a/cmd/certs/inspect_test.go
+++ b/cmd/certs/inspect_test.go
@@ -1,0 +1,247 @@
+package certs
+
+import (
+	"bytes"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/cert"
+	"strings"
+	"testing"
+)
+
+const (
+	pemServerCert = `-----BEGIN CERTIFICATE-----
+MIICtDCCAZygAwIBAgIUNknYnqtlQSl7kpt7BrVp4EAjQyAwDQYJKoZIhvcNAQEL
+BQAwJTEjMCEGA1UEAwwaa3ViZS1jc3Itc2lnbmVyX0AxMjM0NTY3ODkwHhcNMjMw
+NDIxMTQzNDMzWhcNMjQwNDExMTQzNDMzWjBBMRUwEwYDVQQKDAxzeXN0ZW06bm9k
+ZXMxKDAmBgNVBAMMH3N5c3RlbTpub2RlczpteW5vZGUuZXhhbXBsZS5jb20wWTAT
+BgcqhkjOPQIBBggqhkjOPQMBBwNCAAQOWYlirUnQKAViuLVbcabWt2ikmYNB0XVA
+TAznTzMN8h9zRNJyclXRiMO/esAitZC3j0BO2LstdwRjzT5Q3XNIo4GKMIGHMB8G
+A1UdIwQYMBaAFAGbrjSLLirGWLWcJ3TsfqPf+6jmMAkGA1UdEwQCMAAwCwYDVR0P
+BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMDcGA1UdEQQwMC6CH3N5c3RlbTpu
+b2RlczpteW5vZGUuZXhhbXBsZS5jb22CCzE5Mi4xNjguMS4xMA0GCSqGSIb3DQEB
+CwUAA4IBAQAXXpRgZ3gwiFMnYDsmG0h15915vTB8uX8jf/bdhCJWn7LlzJpLuGjl
+o60jf/17tMLgp0l4vcfZDvK7RKWz48j2dfTxd0t82QeMkkD92Hm8yyaQur7XcwtP
+cFWiMmVfLejhnQqBFQgrGMniWJhIN9uQUQul2ANKZ5pwmN8cRt6Oeb9Eg6yHzHUK
+wlo4f3l3lPaihoLE7F3dk4eDBQTCypFQhoxJf+4OMft5fgcC25134MG2ShYiUA9t
+ZQzAy9dZrLzbfQWZ5km/juWC7z3FgS+WNDTd76WrlzVuGW4qBg+0TJ/j4oLpzjrL
+aXN6uc2j4F2o1XAZQdTkKYvTM4nnwe/+
+-----END CERTIFICATE-----`
+
+	pemCaCert = `-----BEGIN CERTIFICATE-----
+MIICODCCAaGgAwIBAgIUeoMh/N7rDvcV4f3d9i+Y1/d95K4wDQYJKoZIhvcNAQEL
+BQAwLjENMAsGA1UECgwEdGVzdDEMMAoGA1UECwwDT3JnMQ8wDQYDVQQDDAZSb290
+Q0EwHhcNMjMwNDIxMDgzNjQxWhcNMjQwNDIwMDgzNjQxWjAuMQ0wCwYDVQQKDAR0
+ZXN0MQwwCgYDVQQLDANPcmcxDzANBgNVBAMMBlJvb3RDQTCBnzANBgkqhkiG9w0B
+AQEFAAOBjQAwgYkCgYEAoY0yhH5lba0xHg/2Ie51F4aFbU2LbBI3CyJGRry0RSCG
+8rnb4WU3kcbHE03JEPQmihU1op73QmxI413mqPNtpqWYYOvL6B9gvVl0bEM5qTnD
+hKfP9h/ekCO4pm+uY3JjiatkIF/W8/0cytbWsUgjfZU96S/uF4g48TxLe1H/Gt8C
+AwEAAaNTMFEwHQYDVR0OBBYEFNqZ+NzXj2tP2NSwjk2HqInVvK56MB8GA1UdIwQY
+MBaAFNqZ+NzXj2tP2NSwjk2HqInVvK56MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+hvcNAQELBQADgYEAe821E08aGjkGYEOK9bFRdzBgHgiA8BHupuz8fJ915YJJijwz
+5DuVRfQSNGNrip5lZMImOv51hmeIyx7MjRyMfX5OTYl3N9jbpG9fN43apmc5LJSl
+VH0XG4zByMNuL8siY1YWrbQ4M35K20i7h51NweWBqhC1tB0wd+dWShrZIJk=
+-----END CERTIFICATE-----`
+	pemServerCsr = `-----BEGIN CERTIFICATE REQUEST-----
+MIIBdzCB4QIBADA4MQ0wCwYDVQQKDAR0ZXN0MQwwCgYDVQQLDANPcmcxGTAXBgNV
+BAMMEGhvc3QuZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
+AMBUPG+Ws5Klgnt/XZeLkMcO0B2X0nF0bWMFbUjISM4+tM9eYgel3DY4nfbTpEJV
+nrArRwQ/t+nxRd9Y9yvEo6MgEmWQBGr5LTZS2NYsCDxf+RxzsjzGQL1J14VFA2lL
+xFvAOvoSgaImuLOWJiX9xgvPTw39PcSFm0/JRAEVP1flAgMBAAGgADANBgkqhkiG
+9w0BAQsFAAOBgQBlr4bgtCa+crQ7MzkuhJQZjHnV3FkI88ZZo2/V1nhpMOw5EPDS
+qM2Ajc3/eUqoj+X9z7iw05Yu5J4wmJvHUwp0OjVrPcE3CIiArSzL+s2HfjMHM0bF
+zvRehNf9rzAatHoAQ0hmpppGB24NebQLl2qeDLVkRwtWoaxS3vKrfa+Fhw==
+-----END CERTIFICATE REQUEST-----`
+)
+
+func TestCertInspectConfigMap(t *testing.T) {
+	tests := []struct {
+		name string
+		cm   *corev1.ConfigMap
+		want string
+	}{
+		{
+			name: "ConfigMap with CA certificate",
+			cm:   getConfigMap(map[string]string{"ca-bundle.crt": pemCaCert}),
+			want: "\"RootCA\" [] groups=[test] issuer=\"<self>\"",
+		},
+		{
+			name: "ConfigMap with invalid CA certificate",
+			cm:   getConfigMap(map[string]string{"ca-bundle.crt": "invalid ca"}),
+			want: "ERROR - data does not contain any valid RSA or ECDSA certificates\n",
+		},
+		{
+			name: "ConfigMap with empty CA certificate",
+			cm:   getConfigMap(map[string]string{"ca-bundle.crt": ""}),
+			want: "MISSING ca-bundle content",
+		},
+		{
+			name: "ConfigMap without ca-bundle.crt key ",
+			cm:   getConfigMap(map[string]string{"invalid key": "invalid ca"}),
+			want: "NOT a ca-bundle",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result bytes.Buffer
+			inspectConfigMap(&result, tt.cm)
+			if !strings.Contains(result.String(), tt.want) {
+				t.Errorf("Got: %v \n", result.String())
+				t.Errorf("Want: %v \n", tt.want)
+			}
+		})
+	}
+}
+
+func TestCertInspectSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   string
+	}{
+		{
+			name:   "Secret with server certificate",
+			secret: getSecret(map[string][]byte{"tls.crt": []byte(pemServerCert)}),
+			want:   "\"system:nodes:mynode.example.com\" [serving] groups=[system:nodes] validServingFor=[system:nodes:mynode.example.com,192.168.1.1] issuer=\"kube-csr-signer_@123456789\"",
+		},
+		{
+			name:   "Secret with invalid server certificate",
+			secret: getSecret(map[string][]byte{"tls.crt": []byte("invalid pem")}),
+			want:   "ERROR - data does not contain any valid RSA or ECDSA certificates\n",
+		},
+		{
+			name:   "Secret with empty server certificate",
+			secret: getSecret(map[string][]byte{"tls.crt": []byte("")}),
+			want:   "MISSING tls.crt content",
+		},
+		{
+			name:   "Secret with CA certificate",
+			secret: getSecret(map[string][]byte{"ca.crt": []byte(pemCaCert)}),
+			want:   "\"RootCA\" [] groups=[test] issuer=\"<self>\"",
+		},
+		{
+			name:   "Secret with invalid CA certificate",
+			secret: getSecret(map[string][]byte{"ca.crt": []byte("invalid ca")}),
+			want:   "ERROR - data does not contain any valid RSA or ECDSA certificates\n",
+		},
+		{
+			name:   "Secret with empty CA certificate",
+			secret: getSecret(map[string][]byte{"ca.crt": []byte("")}),
+			want:   "MISSING ca.crt content",
+		},
+		{
+			name:   "Secret without tls.crt or ca.crt key",
+			secret: getSecret(map[string][]byte{"invalid key": []byte("invalid pem")}),
+			want:   "NOT a tls secret or token secret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result bytes.Buffer
+			inspectSecret(&result, tt.secret)
+			//			t.Errorf("Get: %s\nNeed:%s\n", result.String(), tt.want)
+			if !strings.Contains(result.String(), tt.want) {
+				t.Errorf("Got: %v \n", result.String())
+				t.Errorf("Want: %v \n", tt.want)
+			}
+		})
+	}
+}
+
+func TestCertificateSigningRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		csr  *certificatesv1.CertificateSigningRequest
+		want string
+	}{
+		{
+			name: "valid CertificateSigningRequest",
+			csr:  getCertificateSigningRequest([]byte(pemServerCsr), []byte(pemServerCert)),
+			want: "\"system:nodes:mynode.example.com\" [serving] groups=[system:nodes] validServingFor=[system:nodes:mynode.example.com,192.168.1.1] issuer=\"kube-csr-signer_@123456789\"",
+		},
+		{
+			name: "unsigned CertificateSigningRequest",
+			csr:  getCertificateSigningRequest([]byte(pemServerCsr), []byte("")),
+			want: "NOT SIGNED",
+		},
+		{
+			name: "invalid CertificateSigningRequest",
+			csr:  getCertificateSigningRequest([]byte("invalid"), []byte("abc")),
+			want: "ERROR -",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result bytes.Buffer
+			inspectCSR(&result, tt.csr)
+			if !strings.Contains(result.String(), tt.want) {
+				t.Errorf("Got: %v \n", result.String())
+				t.Errorf("Want: %v \n", tt.want)
+			}
+		})
+	}
+}
+
+func TestCertDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		cert string
+		want string
+	}{
+		{
+			name: "valid node Certificate",
+			cert: pemServerCert,
+			want: "\"system:nodes:mynode.example.com\" [serving] groups=[system:nodes] validServingFor=[system:nodes:mynode.example.com,192.168.1.1] issuer=\"kube-csr-signer_@123456789\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedCert, err := cert.ParseCertsPEM([]byte(tt.cert))
+			if err != nil {
+				t.Errorf("err: %s", err)
+			}
+			for _, cert := range parsedCert {
+				result := certDetail(cert)
+				if !strings.Contains(result, tt.want) {
+					t.Errorf("Got: %v \n", result)
+					t.Errorf("Want: %v \n", tt.want)
+				}
+			}
+		})
+	}
+}
+
+func getConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-configmap",
+			Namespace: "my-namespace",
+		},
+		Data: data,
+	}
+}
+
+func getSecret(data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "openshift-config",
+		},
+		Data: data,
+	}
+}
+
+func getCertificateSigningRequest(data, status []byte) *certificatesv1.CertificateSigningRequest {
+	return &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-csr",
+		},
+		Spec: certificatesv1.CertificateSigningRequestSpec{
+			Request: data,
+		},
+		Status: certificatesv1.CertificateSigningRequestStatus{
+			Certificate: status,
+		},
+	}
+}

--- a/cmd/get/core/configmaps.go
+++ b/cmd/get/core/configmaps.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,10 @@ limitations under the License.
 package core
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/gmeghnag/omc/cmd/helpers"
 	"github.com/gmeghnag/omc/vars"
@@ -37,8 +35,7 @@ type ConfigMapsItems struct {
 	Items      []*corev1.ConfigMap `json:"items"`
 }
 
-func getConfigMaps(currentContextPath string, namespace string, resourceName string, allNamespacesFlag bool, outputFlag string, showLabels bool, jsonPathTemplate string, allResources bool) bool {
-	_headers := []string{"namespace", "name", "data", "age"}
+func GetConfigMaps(currentContextPath string, namespace string, resourceName string, allNamespacesFlag bool, out *[]*corev1.ConfigMap) {
 	var namespaces []string
 	if allNamespacesFlag == true {
 		namespace = "all"
@@ -50,156 +47,30 @@ func getConfigMaps(currentContextPath string, namespace string, resourceName str
 		namespaces = append(namespaces, namespace)
 	}
 
-	var data [][]string
-	var _ConfigMapsList = ConfigMapsItems{ApiVersion: "v1"}
 	for _, _namespace := range namespaces {
 		var _Items ConfigMapsItems
 		CurrentNamespacePath := currentContextPath + "/namespaces/" + _namespace
 		_file, err := ioutil.ReadFile(CurrentNamespacePath + "/core/configmaps.yaml")
 		if err != nil && !allNamespacesFlag {
-			_cm, _ := ioutil.ReadDir(CurrentNamespacePath + "/core/configmaps/")
-			for _, f := range _cm {
-				cmYamlPath := CurrentNamespacePath + "/core/configmaps/" + f.Name()
-				_file := helpers.ReadYaml(cmYamlPath)
-				ConfigMap := corev1.ConfigMap{}
-				if err := yaml.Unmarshal([]byte(_file), &ConfigMap); err != nil {
-					fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+cmYamlPath)
-					os.Exit(1)
-				}
-				_Items.Items = append(_Items.Items, &ConfigMap)
-			}
-			if len(_cm) == 0 {
-				fmt.Fprintln(os.Stderr, "No resources found in "+_namespace+" namespace.")
-				os.Exit(1)
-			}
+			continue
 		}
 		if err := yaml.Unmarshal([]byte(_file), &_Items); err != nil {
 			fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file "+CurrentNamespacePath+"/core/configmaps.yaml")
 			os.Exit(1)
 		}
-
 		for _, ConfigMap := range _Items.Items {
 			labels := helpers.ExtractLabels(ConfigMap.GetLabels())
-			if !helpers.MatchLabels(labels, vars.LabelSelectorStringVar) {
-				continue
+			if vars.LabelSelectorStringVar != "" {
+				if !helpers.MatchLabels(labels, vars.LabelSelectorStringVar) {
+					continue
+				}
 			}
 			if resourceName != "" && resourceName != ConfigMap.Name {
 				continue
 			}
-
-			if outputFlag == "name" {
-				_ConfigMapsList.Items = append(_ConfigMapsList.Items, ConfigMap)
-				fmt.Println("configmap/" + ConfigMap.Name)
-				continue
-			}
-
-			if outputFlag == "yaml" {
-				_ConfigMapsList.Items = append(_ConfigMapsList.Items, ConfigMap)
-				continue
-			}
-
-			if outputFlag == "json" {
-				_ConfigMapsList.Items = append(_ConfigMapsList.Items, ConfigMap)
-				continue
-			}
-
-			if strings.HasPrefix(outputFlag, "jsonpath=") {
-				_ConfigMapsList.Items = append(_ConfigMapsList.Items, ConfigMap)
-				continue
-			}
-
-			//name
-			ConfigMapName := ConfigMap.Name
-			if allResources {
-				ConfigMapName = "configmap/" + ConfigMapName
-			}
-			//data
-			configmapData := strconv.Itoa(len(ConfigMap.Data))
-
-			//age
-			age := helpers.GetAge(CurrentNamespacePath+"/core/", ConfigMap.GetCreationTimestamp())
-
-			_list := []string{ConfigMap.Namespace, ConfigMapName, configmapData, age}
-			data = helpers.GetData(data, allNamespacesFlag, showLabels, labels, outputFlag, 4, _list)
-
-			if resourceName != "" && resourceName == ConfigMapName {
-				break
-			}
-		}
-		if namespace != "" && _namespace == namespace {
-			break
+			*out = append(*out, ConfigMap)
 		}
 	}
-
-	if (outputFlag == "" || outputFlag == "wide") && len(data) == 0 {
-		if !allResources {
-			fmt.Println("No resources found in " + namespace + " namespace.")
-		}
-		return true
-	}
-
-	var headers []string
-	if outputFlag == "" {
-		if allNamespacesFlag == true {
-			headers = _headers[0:4]
-		} else {
-			headers = _headers[1:4]
-		}
-		if showLabels {
-			headers = append(headers, "labels")
-		}
-		helpers.PrintTable(headers, data)
-		return false
-	}
-	if outputFlag == "wide" {
-		if allNamespacesFlag == true {
-			headers = _headers
-		} else {
-			headers = _headers[1:]
-		}
-		if showLabels {
-			headers = append(headers, "labels")
-		}
-		helpers.PrintTable(headers, data)
-		return false
-	}
-
-	if len(_ConfigMapsList.Items) == 0 {
-		if !allResources {
-			fmt.Println("No resources found in " + namespace + " namespace.")
-		}
-		return true
-	}
-
-	var resource interface{}
-	if resourceName != "" {
-		resource = _ConfigMapsList.Items[0]
-	} else {
-		resource = _ConfigMapsList
-	}
-	if outputFlag == "yaml" {
-		y, _ := yaml.Marshal(resource)
-		fmt.Println(string(y))
-	}
-	if outputFlag == "json" {
-		j, _ := json.MarshalIndent(resource, "", "  ")
-		fmt.Println(string(j))
-	}
-	if strings.HasPrefix(outputFlag, "jsonpath=") {
-		helpers.ExecuteJsonPath(resource, jsonPathTemplate)
-	}
-
-	/* var resource interface{}
-	if outputFlag == "yaml" || outputFlag == "json" || outputFlag == "jsonpath" {
-		if resourceName != "" {
-			fmt.Println(_ConfigMapsList.Items[0].Name)
-			resource = _ConfigMapsList.Items[0]
-		} else {
-			resource = _ConfigMapsList
-		}
-	}
-	helpers.PrintOutput(resource, outputFlag, resourceName, allNamespacesFlag, showLabels, _headers, data, jsonPathTemplate)
-	*/return false
 }
 
 var ConfigMap = &cobra.Command{
@@ -211,7 +82,46 @@ var ConfigMap = &cobra.Command{
 		if len(args) == 1 {
 			resourceName = args[0]
 		}
+		var resources []*corev1.ConfigMap
+		GetConfigMaps(vars.MustGatherRootPath, vars.Namespace, resourceName, vars.AllNamespaceBoolVar, &resources)
+		if len(resources) == 0 {
+			fmt.Fprintln(os.Stderr, "No resources found.")
+			os.Exit(0)
+		}
+		_headers := []string{"namespace", "name", "data", "age"}
+		allResources := false
+		var data [][]string
+		for _, ConfigMap := range resources {
+			labels := helpers.ExtractLabels(ConfigMap.GetLabels())
+
+			//name
+			ConfigMapName := ConfigMap.Name
+			if allResources {
+				ConfigMapName = "configmap/" + ConfigMapName
+			}
+			//data
+			configmapData := strconv.Itoa(len(ConfigMap.Data))
+
+			//age
+			age := helpers.GetAge(vars.MustGatherRootPath+"/namespaces/"+ConfigMap.Namespace+"/core/", ConfigMap.GetCreationTimestamp())
+
+			_list := []string{ConfigMap.Namespace, ConfigMapName, configmapData, age}
+			data = helpers.GetData(data, vars.AllNamespaceBoolVar, vars.ShowLabelsBoolVar, labels, vars.OutputStringVar, 4, _list)
+
+			if resourceName != "" && resourceName == ConfigMapName {
+				break
+			}
+		}
+		// ugly hack to get single item out of the slice
+		//  TODO: handle this is helpets.PrintOutput
+		var resourceSliceOrSingle interface{}
+		if resourceName == "" {
+			// for backward-compability print this as a ConfigMapsItems
+			resourceSliceOrSingle = ConfigMapsItems{ApiVersion: "v1", Items: resources}
+		} else {
+			resourceSliceOrSingle = resources[0]
+		}
 		jsonPathTemplate := helpers.GetJsonTemplate(vars.OutputStringVar)
-		getConfigMaps(vars.MustGatherRootPath, vars.Namespace, resourceName, vars.AllNamespaceBoolVar, vars.OutputStringVar, vars.ShowLabelsBoolVar, jsonPathTemplate, false)
+		helpers.PrintOutput(resourceSliceOrSingle, 4, vars.OutputStringVar, resourceName, vars.AllNamespaceBoolVar, vars.ShowLabelsBoolVar, _headers, data, jsonPathTemplate)
 	},
 }

--- a/cmd/helpers/helpers.go
+++ b/cmd/helpers/helpers.go
@@ -16,9 +16,9 @@ import (
 	"github.com/gmeghnag/omc/types"
 
 	"github.com/olekukonko/tablewriter"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/jsonpath"
+	"sigs.k8s.io/yaml"
 )
 
 // TYPES
@@ -248,6 +248,9 @@ func PrintOutput(resource interface{}, columns int16, outputFlag string, resourc
 		PrintTable(headers, data)
 		return false
 	}
+
+	// TODO: de-slice single-item slice into element
+
 	if outputFlag == "yaml" {
 		y, _ := yaml.Marshal(resource)
 		fmt.Println(string(y))

--- a/root/root.go
+++ b/root/root.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gmeghnag/omc/cmd"
 	"github.com/gmeghnag/omc/cmd/alert"
+	"github.com/gmeghnag/omc/cmd/certs"
 	"github.com/gmeghnag/omc/cmd/config"
 	"github.com/gmeghnag/omc/cmd/describe"
 	"github.com/gmeghnag/omc/cmd/etcd"
@@ -80,6 +81,7 @@ func init() {
 		logs.Logs,
 		machineconfig.MachineConfig,
 		upgrade.Upgrade,
+		certs.Certs,
 	)
 	loadOmcConfigs()
 }


### PR DESCRIPTION
This adds an `omc certs inspect` command inspired by the similar command in https://github.com/openshift/cluster-debug-tools. Unfortunately importing it directly causes a dependency hell since we're using different versions of apimachinery and since cluster-debug-tools is not meant to be relied on I'm porting the logic here.

To get here, the relevant get(configmap/secret/csr) functions are refactored for re-usability (... and testability perhaps if we agree to take the same path for other getters).

@gmeghnag let me know what you think