### PR TITLE
Support downloading and extracting tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ go install
 Starting with `v2.1.0` it's possible to upgrade the tool by running `omc upgrade --to=<version>`
 
 ## Usage
-Point it to an **extracted** must-gather:
+Point it to a must-gather. This can be a local extracted must-gather, a local tarball, or a remote tarball:
 ```
 $ omc use </path/to/must-gather/>
 ```

--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -136,6 +136,7 @@ var UseCmd = &cobra.Command{
 	If the must-gather does not exists it will be added as default to the managed must-gathers.
 	Use the command 'omc get mg' to see them all.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
 		idFlag, _ := cmd.Flags().GetString("id")
 		path := ""
 		isCompressedFile := false
@@ -149,13 +150,22 @@ var UseCmd = &cobra.Command{
 		}
 		if len(args) == 1 {
 			path = args[0]
-			if strings.HasSuffix(path, "/") {
-				path = strings.TrimRight(path, "/")
+			if IsRemoteFile(path) {
+				path, err = DownloadFile(path)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+			} else {
+				if strings.HasSuffix(path, "/") {
+					path = strings.TrimRight(path, "/")
+				}
+				if strings.HasSuffix(path, "\\") {
+					path = strings.TrimRight(path, "\\")
+				}
+				path, _ = filepath.Abs(path)
 			}
-			if strings.HasSuffix(path, "\\") {
-				path = strings.TrimRight(path, "\\")
-			}
-			path, _ = filepath.Abs(path)
+
 			isDir, _ := helpers.IsDirectory(path)
 			if !isDir {
 				isCompressedFile, _ = IsCompressedFile(path)

--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -33,13 +33,6 @@ import (
 )
 
 func useContext(path string, omcConfigFile string, idFlag string) {
-	//if path != "" {
-	//	if !filepath.IsAbs(path) {
-	//		fmt.Println("error: \"" + path + "\" is not an absolute path.")
-	//		os.Exit(1)
-	//	}
-	//}
-	// read json omcConfigFile
 	if path != "" {
 		_path, err := findMustGatherIn(path)
 		if err != nil {
@@ -51,6 +44,7 @@ func useContext(path string, omcConfigFile string, idFlag string) {
 		path = strings.TrimSuffix(path, "/")
 	}
 
+	// read json omcConfigFile
 	file, _ := ioutil.ReadFile(omcConfigFile)
 	omcConfigJson := types.Config{}
 	_ = json.Unmarshal([]byte(file), &omcConfigJson)


### PR DESCRIPTION
Allow downloading remote must-gather tarballs. This can be helpful when inspecting e.g. CI logs. In addition, don't attempt to create a directory if extracting a tarball to the current directory.
