### PR TITLE
Try fully qualified resource names in resource group directories

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -198,12 +198,12 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 	}
 	for _, namespace := range namespaces {
 		UnstructuredItems := types.UnstructuredList{ApiVersion: "v1", Kind: "List"}
+
 		resourcePath := fmt.Sprintf("%s/namespaces/%s/%s/%s.yaml", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural)
 		_file, err := ioutil.ReadFile(resourcePath)
 		if err != nil {
 			resourceDir := fmt.Sprintf("%s/namespaces/%s/%s/%s", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural)
 			_, err = os.Stat(resourceDir)
-			// TODO clean up handling of alternative structures
 			if err != nil {
 				resourceDir = fmt.Sprintf("%s/namespaces/%s/%s/%s.%s", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural, resourceGroup)
 				_, err = os.Stat(resourceDir)
@@ -227,6 +227,8 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 						handleObject(item)
 					}
 				}
+			} else {
+				klog.V(3).Info("INFO ", fmt.Sprintf("failed to find resources for: %s", resourceNamePlural))
 			}
 		} else {
 			if err := yaml.Unmarshal(_file, &UnstructuredItems); err != nil {

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -203,6 +203,11 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 		if err != nil {
 			resourceDir := fmt.Sprintf("%s/namespaces/%s/%s/%s", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural)
 			_, err = os.Stat(resourceDir)
+			// TODO clean up handling of alternative structures
+			if err != nil {
+				resourceDir = fmt.Sprintf("%s/namespaces/%s/%s/%s.%s", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural, resourceGroup)
+				_, err = os.Stat(resourceDir)
+			}
 			if err == nil {
 				resourcesFiles, _ := ioutil.ReadDir(resourceDir)
 				for _, f := range resourcesFiles {

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -853,5 +853,63 @@ volumeattachments:
   name: volumeattachment
   namespaced: false
   plural: volumeattachments
-
-
+backup:
+  group: velero.io
+  name: backup
+  namespaced: true
+  plural: backups
+backupstoragelocation:
+  group: velero.io
+  name: backupstoragelocation
+  namespaced: true
+  plural: backupstoragelocations
+deletebackuprequest:
+  group: velero.io
+  name: deletebackuprequest
+  namespaced: true
+  plural: deletebackuprequests
+downloadrequest:
+  group: velero.io
+  name: downloadrequest
+  namespaced: true
+  plural: downloadrequests
+podvolumebackup:
+  group: velero.io
+  name: podvolumebackup
+  namespaced: true
+  plural: podvolumebackups
+podvolumerestore:
+  group: velero.io
+  name: podvolumerestore
+  namespaced: true
+  plural: podvolumerestores
+resticrepository:
+  group: velero.io
+  name: resticrepository
+  namespaced: true
+  plural: resticrepositories
+resticrepositories:
+  group: velero.io
+  name: resticrepository
+  namespaced: true
+  plural: resticrepositories
+restore:
+  group: velero.io
+  name: restore
+  namespaced: true
+  plural: restores
+schedule:
+  group: velero.io
+  name: schedule
+  namespaced: true
+  plural: schedules
+serverstatusrequest:
+  group: velero.io
+  name: serverstatusrequest
+  namespaced: true
+  plural: serverstatusrequests
+volumesnapshotlocation:
+  group: velero.io
+  name: volumesnapshotlocation
+  namespaced: true
+  plural: volumesnapshotlocations

--- a/root/root.go
+++ b/root/root.go
@@ -38,8 +38,10 @@ import (
 	"github.com/gmeghnag/omc/vars"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/viper"
+
+	goflags "flag"
+	"k8s.io/klog/v2"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -60,6 +62,19 @@ func Execute() {
 func init() {
 	//fmt.Println("inside init") //FLOW 0
 	cobra.OnInitialize(initConfig)
+
+	// add klog flags, but hide them from the overall --help information
+	fs := goflags.NewFlagSet("klog", goflags.ExitOnError)
+	klog.InitFlags(fs)
+	RootCmd.PersistentFlags().AddGoFlagSet(fs)
+	for _, f := range []string{"alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size", "logtostderr", "one_output", "skip_headers", "skip_log_headers", "stderrthreshold", "v", "vmodule", "add_dir_header"} {
+		flag := RootCmd.PersistentFlags().Lookup(f)
+		if flag != nil {
+			flag.Hidden = true
+		} else {
+			fmt.Fprintln(os.Stderr, "Failed to find flag to remove "+f)
+		}
+	}
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,


### PR DESCRIPTION
Attempt to use fully-qualified resource names for resource directories when the expected directory is not found.

This allows certain must-gathers, such as OADP, to be used by omc. So for resources such as backups.velero.io, instead of just trying `namespace/velero.io/backups`, it will also attempt to use `namespace/velero.io/backups.velero.io` if the original path cannot be found.

Also add a number of known aliases for OADP resources.

Tested CRD:
- backups
- backupstoragelocations
- downloadrequests
- podvolumebackups
- schedules
- volumesnapshotlocations
- resticrepositories