### PR TITLE
Update install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ```
 # cd to a directory that is in your $PATH
 
-curl -sL https://github.com/gmeghnag/omc/releases/latest/download/omc_$(uname -o)_$(uname -m).tar.gz | tar xzf - omc && chmod +x ./omc
+curl -sL https://github.com/gmeghnag/omc/releases/latest/download/omc_$(uname)_$(uname -m).tar.gz | tar xzf - omc && chmod +x ./omc
 
 omc -h
 ```


### PR DESCRIPTION
I'm trying to install on Fedora 38 and RHEL 9.2 where `uname -o` returns `GNU/Linux` and doesn't work with the install command.

Using just `uname` works good but I'm unable to confirm on MacOS. 

```
[rbost@fedora yank]$ uname -r
6.6.6-100.fc38.x86_64
[rbost@fedora yank]$ uname -o
GNU/Linux
```

```
bash-5.1$ uname -r
5.14.0-284.41.1.el9_2.x86_64
bash-5.1$ uname -o
GNU/Linux
```