### PR TITLE
Add support for automationcontroller crd

### DIFF
--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -888,3 +888,13 @@ oauthclients:
   name: oauthclient
   namespaced: false
   plural: oauthclients
+automationcontroller:
+  group: automationcontroller.ansible.com
+  name: automationcontroller
+  namespaced: true
+  plural: automationcontrollers
+automationcontrollers:
+  group: automationcontroller.ansible.com
+  name: automationcontroller
+  namespaced: true
+  plural: automationcontrollers


### PR DESCRIPTION
This PR adds support for querying the AutomationController CRD for Ansible Automation Platform deployments when using an AAP must-gather. 