### PR TITLE
Add new config to configure default project, closes #149

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,6 +38,8 @@ var ConfigCmd = &cobra.Command{
 func init() {
 	ConfigCmd.PersistentFlags().BoolVarP(&vars.UseLocalCRDs, "use-local-crds", "", false, "If set to true, omc will search for valid CRDs also in ~/.omc/customresourcedefinitions")
 	ConfigCmd.PersistentFlags().StringVarP(&vars.DiffCmd, "diff-command", "", "", "Set the binary tool to use to execute \"omc mc diff <machineConfig1> <machineConfig2>\"")
+	ConfigCmd.PersistentFlags().StringVarP(&vars.DefaultProject, "default-project", "", "", "Set the default context project \"omc config --default-project=<NS>\"")
+
 }
 
 func SetConfig() {
@@ -47,6 +49,7 @@ func SetConfig() {
 	_ = json.Unmarshal([]byte(file), &omcConfigJson)
 	omcConfigJson.UseLocalCRDs = vars.UseLocalCRDs
 	omcConfigJson.DiffCmd = vars.DiffCmd
+	omcConfigJson.DefaultProject = vars.DefaultProject
 	file, _ = json.MarshalIndent(omcConfigJson, "", " ")
 	_ = ioutil.WriteFile(home+"/.omc/omc.json", file, 0644)
 

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmeghnag/omc/types"
+	"github.com/gmeghnag/omc/vars"
+)
+
+// Define a struct to hold each test case
+type testCase struct {
+	name           string
+	useLocalCRDs   bool
+	diffCmd        string
+	defaultProject string
+}
+
+func TestSetConfig(t *testing.T) {
+	// Define your test cases
+	tests := []testCase{
+		{
+			name:           "Test Case 1",
+			useLocalCRDs:   true,
+			diffCmd:        "diff",
+			defaultProject: "project1",
+		},
+		{
+			name:           "Test Case 2",
+			useLocalCRDs:   false,
+			diffCmd:        "diff --unified",
+			defaultProject: "project2",
+		},
+		// Add more tests as needed
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create temporary directory for test
+			tempDir, err := ioutil.TempDir("", "omcConfigTest")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			// Create '.omc' directory inside the temp directory
+			omcDir := filepath.Join(tempDir, ".omc")
+			if err := os.MkdirAll(omcDir, 0755); err != nil {
+				t.Fatalf("Failed to create '.omc' directory: %v", err)
+			}
+
+			// Set test variables according to the current test case
+			vars.UseLocalCRDs = tc.useLocalCRDs
+			vars.DiffCmd = tc.diffCmd
+			vars.DefaultProject = tc.defaultProject
+
+			// Temporarily set the HOME environment variable to the temp directory
+			originalHome := os.Getenv("HOME")
+			if err := os.Setenv("HOME", tempDir); err != nil {
+				t.Fatalf("Failed to set temporary HOME environment variable: %v", err)
+			}
+			defer os.Setenv("HOME", originalHome) // Restore the original HOME value after the test
+
+			// Invoke the function under test
+			SetConfig()
+
+			// Read the config file from the temp dir '.omc' directory
+			testConfigPath := filepath.Join(omcDir, "omc.json")
+			file, err := ioutil.ReadFile(testConfigPath)
+			if err != nil {
+				t.Fatalf("Unable to read config file from temp dir: %v", err)
+			}
+
+			var config types.Config
+			err = json.Unmarshal(file, &config)
+			if err != nil {
+				t.Fatalf("Unable to unmarshal config JSON: %v", err)
+			}
+			if !compareConfig(config, tc) {
+				t.Errorf("Expected config %+v, got %+v", tc, config)
+			}
+		})
+	}
+}
+
+func compareConfig(actualConfig types.Config, tc testCase) bool {
+	if actualConfig.UseLocalCRDs != tc.useLocalCRDs {
+		return false
+	}
+	if actualConfig.DiffCmd != tc.diffCmd {
+		return false
+	}
+	if actualConfig.DefaultProject != tc.defaultProject {
+		return false
+	}
+	return true
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,8 +40,6 @@ func projectDefault(omcConfigFile string, projDefault string) {
 	omcConfigJson := types.Config{}
 	_ = json.Unmarshal([]byte(file), &omcConfigJson)
 
-	config := types.Config{}
-
 	var contexts []types.Context
 	var NewContexts []types.Context
 	contexts = omcConfigJson.Contexts
@@ -62,8 +60,13 @@ func projectDefault(omcConfigFile string, projDefault string) {
 			NewContexts = append(NewContexts, types.Context{Id: c.Id, Path: c.Path, Current: c.Current, Project: c.Project})
 		}
 	}
-
-	config.Contexts = NewContexts
+	config := types.Config{
+		Contexts:       NewContexts,
+		Id:             omcConfigJson.Id,
+		DiffCmd:        omcConfigJson.DiffCmd,
+		DefaultProject: omcConfigJson.DefaultProject,
+		UseLocalCRDs:   omcConfigJson.UseLocalCRDs,
+	}
 	file, err := json.MarshalIndent(config, "", " ")
 	if err != nil {
 		log.Fatal("Json Marshal failed")

--- a/cmd/use/testdata/useContext/must-gather-multipleNS.sample/namespaces/openshift-etcd/openshift-etcd.yaml
+++ b/cmd/use/testdata/useContext/must-gather-multipleNS.sample/namespaces/openshift-etcd/openshift-etcd.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    openshift.io/sa.scc.mcs: s0:c8,c2
+    openshift.io/sa.scc.supplemental-groups: 1000060000/10000
+    openshift.io/sa.scc.uid-range: 1000060000/10000
+    workload.openshift.io/allowed: management
+  creationTimestamp: "2023-01-10T01:35:44Z"
+  labels:
+    kubernetes.io/metadata.name: openshift-etcd
+    openshift.io/run-level: "0"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:openshift.io/node-selector: {}
+        f:labels:
+          .: {}
+          f:kubernetes.io/metadata.name: {}
+          f:openshift.io/run-level: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:openshift.io/sa.scc.mcs: {}
+          f:openshift.io/sa.scc.supplemental-groups: {}
+          f:openshift.io/sa.scc.uid-range: {}
+    manager: cluster-policy-controller
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:workload.openshift.io/allowed: {}
+    manager: cluster-etcd-operator
+    operation: Update
+    time: "2023-01-10T01:58:36Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:pod-security.kubernetes.io/audit: {}
+          f:pod-security.kubernetes.io/enforce: {}
+          f:pod-security.kubernetes.io/warn: {}
+    manager: Go-http-client
+    operation: Update
+    time: "2023-01-10T02:51:14Z"
+  name: openshift-etcd
+  resourceVersion: "25407"
+  uid: 26cc1192-327c-44fd-81f1-0ee667466dea
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/cmd/use/testdata/useContext/must-gather-multipleNS.sample/namespaces/openshift-kube-apiserver/openshift-kube-apiserver.yaml
+++ b/cmd/use/testdata/useContext/must-gather-multipleNS.sample/namespaces/openshift-kube-apiserver/openshift-kube-apiserver.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    openshift.io/sa.scc.mcs: s0:c8,c7
+    openshift.io/sa.scc.supplemental-groups: 1000070000/10000
+    openshift.io/sa.scc.uid-range: 1000070000/10000
+    workload.openshift.io/allowed: management
+  creationTimestamp: "2023-01-10T01:35:44Z"
+  labels:
+    kubernetes.io/metadata.name: openshift-kube-apiserver
+    olm.operatorgroup.uid/89fa8433-cf6e-4bb9-9af7-c39f39789cc2: ""
+    openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "0"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:openshift.io/node-selector: {}
+          f:workload.openshift.io/allowed: {}
+        f:labels:
+          .: {}
+          f:kubernetes.io/metadata.name: {}
+          f:openshift.io/cluster-monitoring: {}
+          f:openshift.io/run-level: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:openshift.io/sa.scc.mcs: {}
+          f:openshift.io/sa.scc.supplemental-groups: {}
+          f:openshift.io/sa.scc.uid-range: {}
+    manager: cluster-policy-controller
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:olm.operatorgroup.uid/89fa8433-cf6e-4bb9-9af7-c39f39789cc2: {}
+    manager: olm
+    operation: Update
+    time: "2023-01-10T02:08:36Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:pod-security.kubernetes.io/audit: {}
+          f:pod-security.kubernetes.io/enforce: {}
+          f:pod-security.kubernetes.io/warn: {}
+    manager: Go-http-client
+    operation: Update
+    time: "2023-01-10T02:51:28Z"
+  name: openshift-kube-apiserver
+  resourceVersion: "25568"
+  uid: 613cbaa2-6b58-4f50-a73f-960c9bc38638
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/cmd/use/testdata/useContext/must-gather-singleNS.sample/namespaces/openshift-etcd/openshift-etcd.yaml
+++ b/cmd/use/testdata/useContext/must-gather-singleNS.sample/namespaces/openshift-etcd/openshift-etcd.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+    openshift.io/sa.scc.mcs: s0:c8,c2
+    openshift.io/sa.scc.supplemental-groups: 1000060000/10000
+    openshift.io/sa.scc.uid-range: 1000060000/10000
+    workload.openshift.io/allowed: management
+  creationTimestamp: "2023-01-10T01:35:44Z"
+  labels:
+    kubernetes.io/metadata.name: openshift-etcd
+    openshift.io/run-level: "0"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:openshift.io/node-selector: {}
+        f:labels:
+          .: {}
+          f:kubernetes.io/metadata.name: {}
+          f:openshift.io/run-level: {}
+    manager: cluster-bootstrap
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:openshift.io/sa.scc.mcs: {}
+          f:openshift.io/sa.scc.supplemental-groups: {}
+          f:openshift.io/sa.scc.uid-range: {}
+    manager: cluster-policy-controller
+    operation: Update
+    time: "2023-01-10T01:35:44Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          f:workload.openshift.io/allowed: {}
+    manager: cluster-etcd-operator
+    operation: Update
+    time: "2023-01-10T01:58:36Z"
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:pod-security.kubernetes.io/audit: {}
+          f:pod-security.kubernetes.io/enforce: {}
+          f:pod-security.kubernetes.io/warn: {}
+    manager: Go-http-client
+    operation: Update
+    time: "2023-01-10T02:51:14Z"
+  name: openshift-etcd
+  resourceVersion: "25407"
+  uid: 26cc1192-327c-44fd-81f1-0ee667466dea
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/cmd/use/use_test.go
+++ b/cmd/use/use_test.go
@@ -1,0 +1,197 @@
+package use
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmeghnag/omc/types"
+)
+
+func TestUseContext(t *testing.T) {
+	singleNSPath := "testdata/useContext/must-gather-singleNS.sample"
+	multipleNSPath := "testdata/useContext/must-gather-multipleNS.sample"
+	testCases := []struct {
+		name           string
+		path           string
+		ignoreConfigID bool // ID will be randomly created so we sometimes need to ignore the generated ID
+		idFlag         string
+		initialFile    string // JSON content for the omcConfigFile
+		expectedFile   string // Expected JSON content after the function call
+	}{
+		{
+			name: "test1",
+			path: singleNSPath,
+			initialFile: `{
+                "id": "eFqOopAs",
+				"contexts": [
+					{
+					 "id": "eFqOopAs",
+					 "path": "testdata/useContext/must-gather-singleNS.sample",
+					 "current": "*",
+					 "project": "openshift-etcd"
+					}
+				   ],
+                "default_project": "openshift-etcd"
+            }`,
+			expectedFile: `{
+                "id": "eFqOopAs",
+				"contexts": [
+					{
+					 "id": "eFqOopAs",
+					 "path": "testdata/useContext/must-gather-singleNS.sample",
+					 "current": "*",
+					 "project": "openshift-etcd"
+					}
+				   ],
+                "default_project": "openshift-etcd"
+            }`,
+		},
+		{
+			name: "test2",
+			path: multipleNSPath,
+			initialFile: `{
+                "id": "eFqOopAs",
+				"contexts": [
+					{
+					 "id": "eFqOopAs",
+					 "path": "testdata/useContext/must-gather-multipleNS.sample",
+					 "current": "*",
+					 "project": "openshift-etcd"
+					}
+				   ],
+                "default_project": "openshift-etcd"
+            }`,
+			expectedFile: `{
+                "id": "eFqOopAs",
+				"contexts": [
+					{
+					 "id": "eFqOopAs",
+					 "path": "testdata/useContext/must-gather-multipleNS.sample",
+					 "current": "*",
+					 "project": "openshift-etcd"
+					}
+				   ],
+                "default_project": "openshift-etcd"
+            }`,
+		},
+		{
+			name:           "test3",
+			path:           singleNSPath,
+			ignoreConfigID: true,
+			initialFile: `{
+                "default_project": "openshift-etcd"
+            }`,
+			expectedFile: `{
+				"id": "WuLN4pDY",
+				"contexts": [
+				 {
+				  "id": "WuLN4pDY",
+				  "path": "testdata/useContext/must-gather-singleNS.sample",
+				  "current": "*",
+				  "project": "openshift-etcd"
+				 }
+				],
+				"default_project": "openshift-etcd"
+            }`,
+		},
+		{
+			name:           "test4",
+			path:           multipleNSPath,
+			ignoreConfigID: true,
+			initialFile: `{
+            }`,
+			expectedFile: `{
+				"id": "WuLN4pDY",
+				"contexts": [
+				 {
+				  "id": "WuLN4pDY",
+				  "path": "testdata/useContext/must-gather-multipleNS.sample",
+				  "current": "*",
+				  "project": "default"
+				 }
+				]
+            }`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup temporary directory for testing
+			tempDir, err := ioutil.TempDir("", "testusecontext")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir) // Clean up
+
+			// Prepare the omcConfigFile path and initial content
+			configFilePath := filepath.Join(tempDir, "omc.json")
+			if err := ioutil.WriteFile(configFilePath, []byte(tc.initialFile), 0666); err != nil {
+				t.Fatalf("Unable to write initial file: %v", err)
+			}
+
+			useContext(tc.path, configFilePath, tc.idFlag)
+
+			// Validate the file after function call
+			writtenFileContent, err := ioutil.ReadFile(configFilePath)
+			if err != nil {
+				t.Fatalf("Failed to read back the file: %v", err)
+			}
+			// Normalize JSON contents for comparison, since JSON formatting may differ
+			var actualConfig, expectedConfig types.Config
+			if err := json.Unmarshal(writtenFileContent, &actualConfig); err != nil {
+				t.Fatalf("Failed to unmarshal actual file: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tc.expectedFile), &expectedConfig); err != nil {
+				t.Fatalf("Failed to unmarshal expected file: %v", err)
+			}
+
+			// Compare actual config with expected config
+			if !compareConfig(actualConfig, expectedConfig, tc.ignoreConfigID) {
+				t.Errorf("Expected file content %+v, got %+v", expectedConfig, actualConfig)
+			}
+		})
+	}
+}
+
+func compareContexts(actualContext []types.Context, expectedContext []types.Context, ignoreContextID bool) bool {
+	if len(actualContext) != len(expectedContext) {
+		return false
+	}
+
+	for i, actual := range actualContext {
+		expected := expectedContext[i]
+
+		if !ignoreContextID && actual.Id == "" {
+			if actual.Id != expected.Id {
+				return false
+			}
+		}
+		if actual.Path != expected.Path {
+			return false
+		}
+		if actual.Project != expected.Project {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareConfig(actualConfig types.Config, expectedConfig types.Config, ignoreConfigID bool) bool {
+
+	if !ignoreConfigID && actualConfig.Id != expectedConfig.Id {
+		return false
+	}
+
+	if actualConfig.DefaultProject != expectedConfig.DefaultProject ||
+		actualConfig.DiffCmd != expectedConfig.DiffCmd ||
+		actualConfig.UseLocalCRDs != expectedConfig.UseLocalCRDs {
+		return false
+	}
+
+	// This line executes after all the condition checks.
+	return compareContexts(actualConfig.Contexts, expectedConfig.Contexts, ignoreConfigID)
+}

--- a/root/root.go
+++ b/root/root.go
@@ -182,4 +182,5 @@ func loadOmcConfigs() {
 	_ = json.Unmarshal([]byte(file), &omcConfigJson)
 	vars.UseLocalCRDs = omcConfigJson.UseLocalCRDs
 	vars.DiffCmd = omcConfigJson.DiffCmd
+	vars.DefaultProject = omcConfigJson.DefaultProject
 }

--- a/types/types.go
+++ b/types/types.go
@@ -26,10 +26,11 @@ type Context struct {
 }
 
 type Config struct {
-	Id           string    `json:"id,omitempty"`
-	Contexts     []Context `json:"contexts,omitempty"`
-	UseLocalCRDs bool      `json:"use_local_crds,omitempty"`
-	DiffCmd      string    `json:"diff_command,omitempty"`
+	Id             string    `json:"id,omitempty"`
+	Contexts       []Context `json:"contexts,omitempty"`
+	UseLocalCRDs   bool      `json:"use_local_crds,omitempty"`
+	DiffCmd        string    `json:"diff_command,omitempty"`
+	DefaultProject string    `json:"default_project,omitempty"`
 }
 
 type DescribeClient struct {

--- a/vars/vars.go
+++ b/vars/vars.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
-var CfgFile, Namespace, MustGatherRootPath, OutputStringVar, LabelSelectorStringVar, Id, Container, OMCVersionHash, OMCVersionTag, DiffCmd, CurrentKind, LastKind string
+var CfgFile, Namespace, MustGatherRootPath, OutputStringVar, LabelSelectorStringVar, Id, Container, OMCVersionHash, OMCVersionTag, DiffCmd, CurrentKind, LastKind, DefaultProject string
 var AllNamespaceBoolVar, ShowLabelsBoolVar, Previous, AllContainers, UseLocalCRDs, SingleResource, Wide, ShowKind, ShowNamespace, ShowManagedFields, NoHeaders, InsecureLogs bool
 
 var GetArgs map[string]map[string]struct{}


### PR DESCRIPTION
This PR does the following:
1. Add a new config item to configure user's default project in omc.json
```
$ rm -rf ~/.omc/omc.json
$ ./omc config --default-project="openshift-etcd"
$ cat ~/.omc/omc.json
{
 "default_project": "openshift-etcd"
}

```
2. "omc use" will read user's omc.json and set context.project accordingly
```
$ ./omc use cmd/use/testdata/useContext/must-gather-multipleNS.sample
$ cat ~/.omc/omc.json
{
 "id": "YNIUr8Xz",
 "contexts": [
  {
   "id": "YNIUr8Xz",
   "path": "/Users/cchen/Code/github/omc/cmd/use/testdata/useContext/must-gather-multipleNS.sample",
   "current": "*",
   "project": "openshift-etcd"
  }
 ],
 "default_project": "openshift-etcd"
}
$ ./omc project
Using project "openshift-etcd" on must-gather "/Users/cchen/Code/github/omc/cmd/use/testdata/useContext/must-gather-multipleNS.sample".
```
3. Add config_test.go and use_test.go for some basic tests