### PR TITLE
Fixes #154: Getting resources with singular/short names

### DIFF
--- a/cmd/get/helpers.go
+++ b/cmd/get/helpers.go
@@ -63,19 +63,10 @@ func validateArgs(args []string) error {
 				if err == nil {
 					_, ok := vars.GetArgs[resourceNamePlural+"."+resourceGroup]
 					if !ok {
-						if !strings.Contains(resourceType, ".") {
-							vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
-							vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
-						} else {
-							vars.GetArgs[resourceType] = make(map[string]struct{})
-							vars.GetArgs[resourceType][resourceName] = struct{}{}
-						}
+						vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
+						vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 					} else {
-						if !strings.Contains(resourceType, ".") {
-							vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
-						} else {
-							vars.GetArgs[resourceType][resourceName] = struct{}{}
-						}
+						vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 					}
 				} else {
 					return fmt.Errorf("resource type \"%s\" not known.", resourceType)
@@ -91,11 +82,7 @@ func validateArgs(args []string) error {
 		resourceType := args[0]
 		resourceNamePlural, resourceGroup, _, err := kindGroupNamespaced(resourceType)
 		if err == nil {
-			if !strings.Contains(resourceType, ".") {
-				vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
-			} else {
-				vars.GetArgs[resourceType] = make(map[string]struct{})
-			}
+			vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
 		} else {
 			return fmt.Errorf("resource type \"%s\" not known.", resourceType)
 		}
@@ -106,11 +93,7 @@ func validateArgs(args []string) error {
 			if strings.Contains(resourceName, "/") {
 				return fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'omc get resource/<resource_name>' instead of 'omc get resource resource/<resource_name>'")
 			}
-			if !strings.Contains(resourceType, ".") {
-				vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
-			} else {
-				vars.GetArgs[resourceType][resourceName] = struct{}{}
-			}
+			vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 		}
 	}
 	return nil


### PR DESCRIPTION
When a qualified resource name is used in `omc get`, the `<resourceType>` variable is used to set a value in the `vars.GetArgs` object [here](https://github.com/gmeghnag/omc/blob/9acc721d2bd51af167b0827dff60c768ba60d098/cmd/get/helpers.go#L15-L117). The code [here](https://github.com/gmeghnag/omc/blob/9acc721d2bd51af167b0827dff60c768ba60d098/cmd/get/get.go#L99-L109)  uses the value of `<resourceNamePlural>.<resourceGroup>` to retrieve this value. A mismatch between the values of `<resourceType>` and  `<resourceNamePlural>.<resourceGroup>` would cause the described bug in https://github.com/gmeghnag/omc/issues/154.

The resourceType variable is populated directly from the command line. Therefore, this mismatch will occur if the shortname or singular resource name is used as part of the qualified resource name. 

For example with the MachineConfigPool resource, 
| Command | Result |
| --- | --- |
| omc get mcp.machineconfiguration.openshift.io master | ❌ |
| omc get machineconfigpool.machineconfiguration.openshift.io master | ❌ |
| omc get machineconfigpools.machineconfiguration.openshift.io master| ✅ |

This PR fixes this bug by using `<resourceNamePlural>.<resourceGroup>` to populate the vars.GetArgs argument where a resource with a specific name needs to be retrieved. This is for both the`omc get <resource>/<name>` and `omc get <resource> <name>` forms of retrieving a resource. 
