### PR TITLE
Add description for describe command

### DIFF
--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -29,6 +29,7 @@ import (
 // DescribeCmd represents the describe command
 var DescribeCmd = &cobra.Command{
 	Use: "describe",
+	Short: "Show details of a specific resource or group of resources",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Help()


### PR DESCRIPTION
Added a description for the `describe` command, which is similar to the `oc describe` command description.