### PR TITLE
Add description for node-logs command

### DIFF
--- a/cmd/node-logs/node-logs.go
+++ b/cmd/node-logs/node-logs.go
@@ -11,6 +11,7 @@ import (
 
 var NodeLogs = &cobra.Command{
 	Use: "node-logs",
+	Short: "Display and filter node logs.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			fmt.Println("The following node services logs are available to be read:")


### PR DESCRIPTION
Added a description for the `node-logs` command, which is similar to the `oc adm node-logs` command description.
