### PR TITLE
add "k8s.ovn.org/host-cidrs" for OCP 4.14

### DIFF
--- a/cmd/ovn/subnets.go
+++ b/cmd/ovn/subnets.go
@@ -85,12 +85,27 @@ var SubnetsCmd = &cobra.Command{
 						ipv4Array = append(ipv4Array, ip)
 					}
 				}
-				if len(ipv4Array) != 0 {
-					ipv4String = strings.Join(ipv4Array, ",")
+			}
+			// "k8s.ovn.org/host-addresses" was renamed to "k8s.ovn.org/host-cidrs" in 4.14
+			hostCIDRS := Node.ObjectMeta.Annotations["k8s.ovn.org/host-cidrs"]
+			if hostCIDRS != "" {
+				err := yaml.Unmarshal([]byte(hostCIDRS), &ipsArray)
+				if err != nil {
+					panic(err)
 				}
-				if len(ipv6Array) != 0 {
-					ipv6String = strings.Join(ipv6Array, ",")
+				for _, ip := range ipsArray {
+					if strings.Contains(ip, ":") {
+						ipv6Array = append(ipv6Array, ip)
+					} else {
+						ipv4Array = append(ipv4Array, ip)
+					}
 				}
+			}
+			if len(ipv4Array) != 0 {
+				ipv4String = strings.Join(ipv4Array, ",")
+			}
+			if len(ipv6Array) != 0 {
+				ipv6String = strings.Join(ipv6Array, ",")
 			}
 			if ipv6String != "" {
 				row = append(row, ipv6String)


### PR DESCRIPTION
In upstream OVN "k8s.ovn.org/host-addresses" was renamed to "k8s.ovn.org/host-cidrs" in 4.14

https://github.com/ovn-org/ovn-kubernetes/pull/3915

```
omc ovn subnets
HOST/NODE                     ROLE                   HOST IPV6-ADDRESSES                                                      HOST IP-ADDRESSES                 PRIMARY IF-ADDRESS   HOST GATEWAY-IP         NODE SUBNET
ci-ln--l6zc2-master-0         control-plane,master   fd65:a1a7:60ad:1240:66d5:3dc:317f:ddab/64,fd65:a1a7:60ad:1240::12/127    10.37.202.17/25                   10.37.202.17/25      10.37.202.1,fe70::4d7   10.127.0.0/23,fd65:10:127::/64
ci-ln--l6zc2-master-1         control-plane,master   fd65:a1a7:60ad:1240:5d7a:f70f:ec53:77ac/64,fd65:a1a7:60ad:1240::30/127   10.37.202.116/25                  10.37.202.116/25     10.37.202.1,fe70::4d7   10.129.0.0/23,fd65:10:127:1::/64
ci-ln--l6zc2-master-2         control-plane,master   fd65:a1a7:60ad:1240::37/127,fd65:a1a7:60ad:1240:e6e:6701:fe46:7c09/64    10.37.202.112/25,10.37.202.2/32   10.37.202.112/25     10.37.202.1,fe70::4d7   10.130.0.0/23,fd65:10:127:2::/64
ci-ln--l6zc2-worker-0-jzznw   worker                 fd65:a1a7:60ad:1240:411f:e4ed:fecb:7f94/64,fd65:a1a7:60ad:1240::19/127   10.37.202.3/32,10.37.202.37/25    10.37.202.37/25      10.37.202.1,fe70::4d7   10.131.0.0/23,fd65:10:127:3::/64
ci-ln--l6zc2-worker-0-z2zkz   worker                 fd65:a1a7:60ad:1240::f/127,fd65:a1a7:60ad:1240:c07a:57ec:a59c:66a/64     10.37.202.77/25                   10.37.202.77/25      10.37.202.1,fe70::4d7   10.129.2.0/23,fd65:10:127:4::/64
ci-ln--l6zc2-worker-0-zgv7k   worker                 fd65:a1a7:60ad:1240:2f91:aa66:c3a:676/64,fd65:a1a7:60ad:1240::23/127     10.37.202.46/25                   10.37.202.46/25      10.37.202.1,fe70::4d7   10.127.2.0/23,fd65:10:127:5::/64
```