### PR TITLE
Order the resources in get

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	goyaml "gopkg.in/yaml.v2"
@@ -478,6 +479,7 @@ func handleOutput(w io.Writer) {
 			includesClusterScoped = true
 		}
 	}
+	sort.Strings(_resources)
 	resources := strings.Join(_resources, ",")
 	if vars.OutputStringVar == "json" {
 		if vars.SingleResource && len(vars.UnstructuredList.Items) == 1 {


### PR DESCRIPTION
It seems that sometimes the test could fail because map doesn't guarantee the order. To reproduce it, simply run the test and the test will fail at TestHandleEmptyWideOutput
```
$ go test ./... -count=50
```

With this patch, the test no longer fails