### PR TITLE
Update in-memory namespace on use

### DIFF
--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -64,6 +64,7 @@ func useContext(path string, omcConfigFile string, idFlag string) error {
 			NewContexts = append(NewContexts, types.Context{Id: c.Id, Path: c.Path, Current: "*", Project: c.Project})
 			configId = c.Id
 			found = true
+			vars.Namespace = c.Project
 		} else {
 			NewContexts = append(NewContexts, types.Context{Id: c.Id, Path: c.Path, Current: "", Project: c.Project})
 		}
@@ -80,8 +81,10 @@ func useContext(path string, omcConfigFile string, idFlag string) error {
 			}
 			if len(namespaces) == 1 {
 				NewContexts = append(NewContexts, types.Context{Id: ctxId, Path: path, Current: "*", Project: namespaces[0]})
+				vars.Namespace = namespaces[0]
 			} else {
 				NewContexts = append(NewContexts, types.Context{Id: ctxId, Path: path, Current: "*", Project: defaultProject})
+				vars.Namespace = defaultProject
 			}
 		}
 


### PR DESCRIPTION
Ensure the in-memory state of a must-gather/inspect's path and project are consistent with the context being used, regardless of wether the context is new.

Fixes #171

As I don't have the full context on the use of the global variables in the `vars` package, I advise reviewing if updating `vars.Namespace` has any impact elsewhere.

Unit tests are provided.