### PR TITLE
Add support for PodNetworkConnectivityChecks

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -103,6 +103,8 @@ var GetCmd = &cobra.Command{
 				getClusterLoggingResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			} else if resourceNamePlural == "clusterlogforwarders" {
 				getClusterLogForwarderResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			} else if resourceNamePlural == "podnetworkconnectivitychecks" {
+				getPodNetworkConnectivityChecksResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			} else if namespaced {
 				getNamespacedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			} else {
@@ -541,6 +543,24 @@ func handleOutput(w io.Writer) {
 			}
 		} else {
 			vars.Output.WriteTo(w)
+		}
+	}
+}
+
+func getPodNetworkConnectivityChecksResources(resourceNamePlural string, resourceGroup string, resources map[string]struct{}) {
+	resourcesYamlPath := vars.MustGatherRootPath + "/pod_network_connectivity_check/podnetworkconnectivitychecks.yaml"
+	_file, err := ioutil.ReadFile(resourcesYamlPath)
+	if err == nil {
+		UnstructuredItems := types.UnstructuredList{ApiVersion: "v1", Kind: "List"}
+		if err := yaml.Unmarshal(_file, &UnstructuredItems); err != nil {
+			fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourcesYamlPath)
+			os.Exit(1)
+		}
+		for _, item := range UnstructuredItems.Items {
+			_, ok := resources[item.GetName()]
+			if ok || len(resources) == 0 {
+				handleObject(item)
+			}
 		}
 	}
 }

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -888,8 +888,3 @@ oauthclients:
   name: oauthclient
   namespaced: false
   plural: oauthclients
-podnetworkconnectivitychecks:
-  group: controlplane.operator.openshift.io
-  name: podnetworkconnectivitychecks
-  namespaced: false
-  plural: podnetworkconnectivitychecks

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -888,3 +888,8 @@ oauthclients:
   name: oauthclient
   namespaced: false
   plural: oauthclients
+podnetworkconnectivitychecks:
+  group: controlplane.operator.openshift.io
+  name: podnetworkconnectivitychecks
+  namespaced: false
+  plural: podnetworkconnectivitychecks


### PR DESCRIPTION
PodNetworkConnectivityChecks are saved in the must-gather under `<mg.path>/pod_network_connectivity_check/podnetworkconnectivitychecks.yaml`

This adds support to `omc` by allowing you to view them by running `omc get podnetworkconnectivitychecks -n openshift-diagnostics`

```bash
$ omc get podnetworkconnectivitychecks -n openshift-network-diagnostics
NAME                                                            AGE
network-check-source-10-to-kubernetes-default-service-cluster   239d
```