### PR TITLE
[Upgrade] Create temp file when upgrading, closes #176

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           && env GOOS=linux CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc \
           && tar -cvzf omc_Linux_arm64.tar.gz omc && cp omc_Linux_arm64.tar.gz omc_Linux_aarch64.tar.gz && rm -rf omc \
           && env GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc \
-          && cp omc omc_Darwin_x86_64 && tar -cvzf omc_Darwin_x86_64.tar.gz omc && rm -rf omc \
+          && cp omc omc_Darwin_x86_64 && cp omc omc_Darwin_amd64 && tar -cvzf omc_Darwin_x86_64.tar.gz omc && rm -rf omc \
           && env GOOS=darwin CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc \
           && cp omc omc_Darwin_arm64 && tar -cvzf omc_Darwin_arm64.tar.gz omc && cp omc_Darwin_arm64.tar.gz omc_Darwin_aarch64.tar.gz && rm -rf omc \
           && env GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc.exe \
@@ -61,6 +61,7 @@ jobs:
             omc_Darwin_x86_64.tar.gz
             omc_Darwin_arm64
             omc_Darwin_arm64.tar.gz
+            omc_Darwin_amd64
             omc_Darwin_aarch64.tar.gz
             omc_Windows_x86_64.zip
           name: "${{ env.RELEASE_TAG }} release"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           && go version
       - name: Build
         run: |
-          echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV 
+          echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           TAG="${GITHUB_REF#refs/tags/}"
           HASH=$(git log -n1 --pretty=format:%h)
           echo ${TAG} ${HASH}
@@ -34,7 +34,7 @@ jobs:
           && env GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc \
           && cp omc omc_Darwin_x86_64 && tar -cvzf omc_Darwin_x86_64.tar.gz omc && rm -rf omc \
           && env GOOS=darwin CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc \
-          && tar -cvzf omc_Darwin_arm64.tar.gz omc && cp omc_Darwin_arm64.tar.gz omc_Darwin_aarch64.tar.gz && rm -rf omc \
+          && cp omc omc_Darwin_arm64 && tar -cvzf omc_Darwin_arm64.tar.gz omc && cp omc_Darwin_arm64.tar.gz omc_Darwin_aarch64.tar.gz && rm -rf omc \
           && env GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "-X 'github.com/gmeghnag/omc/vars.OMCVersionTag=${TAG}' -X github.com/gmeghnag/omc/vars.OMCVersionHash=${HASH}" -o omc.exe \
           && zip omc_Windows_x86_64.zip omc.exe \
           && md5sum omc_Linux_x86_64.tar.gz | tee -a checksums.txt \
@@ -44,6 +44,7 @@ jobs:
           && md5sum omc_Darwin_arm64.tar.gz | tee -a checksums.txt \
           && md5sum omc_Darwin_aarch64.tar.gz | tee -a checksums.txt \
           && md5sum omc_Windows_x86_64.zip | tee -a checksums.txt \
+          && md5sum omc_Darwin_arm64 | tee -a checksums.txt \
           && md5sum omc_Darwin_x86_64 | tee -a checksums.txt \
           && md5sum omc_Linux_x86_64| tee -a checksums.txt
       - name: Release
@@ -53,12 +54,13 @@ jobs:
           files: |
             checksums.txt
             omc_Linux_x86_64
-            omc_Linux_x86_64.tar.gz 
-            omc_Linux_arm64.tar.gz 
+            omc_Linux_x86_64.tar.gz
+            omc_Linux_arm64.tar.gz
             omc_Linux_aarch64.tar.gz
             omc_Darwin_x86_64
             omc_Darwin_x86_64.tar.gz
-            omc_Darwin_arm64.tar.gz 
-            omc_Darwin_aarch64.tar.gz 
+            omc_Darwin_arm64
+            omc_Darwin_arm64.tar.gz
+            omc_Darwin_aarch64.tar.gz
             omc_Windows_x86_64.zip
           name: "${{ env.RELEASE_TAG }} release"

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -28,6 +28,8 @@ import (
 
 var DesiredVersion string
 
+const omcDarwinFile = "omc_Darwin"
+
 func upgradeBinary(repoName string) {
 	ex, err := os.Executable()
 	if err != nil {
@@ -59,9 +61,11 @@ func upgradeBinary(repoName string) {
 		fmt.Println("This command is not available for windows.")
 		fmt.Println("Open an issue on the GitHub repo https://github.com/gmeghnag/omc if you want it impemented.")
 	case "darwin":
-		omcUrl := "https://github.com/" + repoName + "/releases/download/" + DesiredVersion + "/omc_Darwin_x86_64"
+		arch := runtime.GOARCH
+		omcBinFile := omcDarwinFile + "_" + arch
+		omcUrl := "https://github.com/" + repoName + "/releases/download/" + DesiredVersion + "/" + omcBinFile
 		if DesiredVersion == "latest" {
-			omcUrl = "https://github.com/" + repoName + "/releases/" + DesiredVersion + "/download/omc_Darwin_x86_64"
+			omcUrl = "https://github.com/" + repoName + "/releases/" + DesiredVersion + "/download/" + omcBinFile
 		}
 		err = updateOmcExecutable(omcExecutablePath, omcUrl, DesiredVersion)
 		if err != nil {


### PR DESCRIPTION
This PR does the following things:

1. Create a temp file when upgrading the omc binary to fix #176 
2. Add M-series MacOS in the build workflow so that arm64 binary could be downloaded in the releases