### PR TITLE
Update verbiage in node-logs.go

### DIFF
--- a/cmd/node-logs/node-logs.go
+++ b/cmd/node-logs/node-logs.go
@@ -10,17 +10,17 @@ import (
 )
 
 var NodeLogs = &cobra.Command{
-	Use: "node-logs",
+	Use:   "node-logs",
 	Short: "Display and filter node logs.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Println("The following node services logs are available to be read:")
+			fmt.Println("The following node service logs are available to be displayed:")
 			fmt.Println("")
 			files, _ := os.ReadDir(vars.MustGatherRootPath + "/host_service_logs/masters/")
 			for _, f := range files {
 				fmt.Println("-", strings.TrimSuffix(f.Name(), "_service.log"))
 			}
-			fmt.Println("\nis it possible to read the content by executing 'omc node-logs <SERVICE>'.")
+			fmt.Println("\nExecuting 'omc node-logs <SERVICE>' will display the logs.")
 		}
 		if len(args) > 1 {
 			fmt.Fprintln(os.Stderr, "Expect zero arguemnt, found: ", len(args))


### PR DESCRIPTION
When running `omc node-logs` it prints a questions "Is it possible to read..."

I made so small verbiage changes to make it clear what is expected.