### PR TITLE
check resource file validity

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -208,7 +208,10 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 			resourceDir := fmt.Sprintf("%s/namespaces/%s/%s/%s", vars.MustGatherRootPath, namespace, resourceGroup, resourceNamePlural)
 			_, err = os.Stat(resourceDir)
 			if err == nil {
-				resourcesFiles, _ := ioutil.ReadDir(resourceDir)
+				resourcesFiles, rErr := ReadDirForResources(resourceDir)
+				if rErr != nil {
+					klog.V(3).ErrorS(err, "Failed to read resources:")
+				}
 				for _, f := range resourcesFiles {
 					resourceYamlPath := resourceDir + "/" + f.Name()
 					_file, _ := ioutil.ReadFile(resourceYamlPath)
@@ -233,12 +236,11 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 			if resourceNamePlural == "pods" {
 				// tranverse the pods directory and fill in UnstructuredItems.Items
 				podsDir := fmt.Sprintf("%s/namespaces/%s/pods", vars.MustGatherRootPath, namespace)
-				pods, _ := os.ReadDir(podsDir)
+				pods, rErr := ReadDirForResources(podsDir)
+				if rErr != nil {
+					klog.V(3).ErrorS(err, "Failed to read resources:")
+				}
 				for _, pod := range pods {
-					// skip dot-prefixed files (e.g. "AppleDouble encoded Macintosh file")
-					if pod.Name()[0] == '.' {
-						continue
-					}
 					podName := pod.Name()
 					podPath := fmt.Sprintf("%s/%s/%s.yaml", podsDir, podName, podName)
 					_file, err := ioutil.ReadFile(podPath)
@@ -310,7 +312,10 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 	_file, err := ioutil.ReadFile(resourcePath)
 	if err != nil {
 		resourceDir := fmt.Sprintf("%s/cluster-scoped-resources/%s/%s", vars.MustGatherRootPath, resourceGroup, resourceNamePlural)
-		resourcesFiles, _ := ioutil.ReadDir(resourceDir)
+		resourcesFiles, rErr := ReadDirForResources(resourceDir)
+		if rErr != nil {
+			klog.V(3).ErrorS(err, "Failed to read resources:")
+		}
 		for _, f := range resourcesFiles {
 			resourceYamlPath := resourceDir + "/" + f.Name()
 			_file, _ := ioutil.ReadFile(resourceYamlPath)

--- a/cmd/get/helpers_test.go
+++ b/cmd/get/helpers_test.go
@@ -1,0 +1,86 @@
+package get
+
+import (
+	"io/fs"
+	"reflect"
+	"sort"
+	"testing"
+	"testing/fstest"
+)
+
+func TestReadDirForResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       fstest.MapFS
+		expected []string
+	}{
+		{
+			name: "read correct resource files/dirs",
+			in: fstest.MapFS{
+				"resource-file-1.yaml":            {Data: []byte("abc")},
+				"resource.yaml":                   {Data: []byte("abc")},
+				"1.yaml":                          {Data: []byte("abc")},
+				"resource.with.dot.filename.yaml": {Data: []byte("abc")},
+				"resource-directory-name":         {Data: []byte("abc"), Mode: fs.ModeDir},
+				"resource.directory.with.dot":     {Data: []byte("abc"), Mode: fs.ModeDir},
+			},
+			expected: []string{
+				"resource-file-1.yaml",
+				"resource.yaml",
+				"1.yaml",
+				"resource.with.dot.filename.yaml",
+				"resource-directory-name",
+				"resource.directory.with.dot",
+			},
+		},
+		{
+			name: "read only resource files/dirs matching the expected name convention",
+			in: fstest.MapFS{
+				"resource-file-1.yaml":             {Data: []byte("abc")},
+				"._faulthy-resource-filename.yaml": {Data: []byte("abc")}, // e.g. AppleDouble encoded Macintosh file
+				".resource-filename.yaml.swp":      {Data: []byte("abc")},
+				"-resource-filename.yaml":          {Data: []byte("abc")},
+			},
+			expected: []string{"resource-file-1.yaml"},
+		},
+		{
+			name: "read only resource files/dir with size > 0",
+			in: fstest.MapFS{
+				"resource-file-1.yaml":         {Data: []byte("abc")},
+				"empty-resource-filename.yaml": {},
+			},
+			expected: []string{"resource-file-1.yaml"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := readDirForResources(tc.in)
+			if len(got) != len(tc.expected) {
+				t.Errorf("Got: %v \n", got)
+				t.Errorf("Want: %v \n", tc.expected)
+			} else {
+				gotNames := make([]string, 0)
+				for _, dir := range got {
+					gotNames = append(gotNames, dir.Name())
+				}
+				sort.Slice(gotNames, func(i, j int) bool {
+					return gotNames[i] > gotNames[j]
+				})
+				sort.Slice(tc.expected, func(i, j int) bool {
+					return tc.expected[i] > tc.expected[j]
+				})
+				if !reflect.DeepEqual(gotNames, tc.expected) {
+					t.Error("Got:")
+					for _, g := range gotNames {
+						t.Error(g)
+					}
+					t.Error("Want:")
+					for _, te := range tc.expected {
+						t.Error(te)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a continuation on #187 since the issue turns out wider then initially thought.
This introduces a wrapper around `fs.ReadDir` to only return "valid" resource files/directories.

Also fixed #180.