### PR TITLE
Fix: Ensure constant format strings in fmt and printf calls

### DIFF
--- a/cmd/certs/inspect.go
+++ b/cmd/certs/inspect.go
@@ -174,7 +174,7 @@ func (c CertDetail) MarshalJSON() ([]byte, error) {
 
 func printParseFailure(w io.Writer, f string) {
 	if showParseFailure {
-		fmt.Fprintf(w, f)
+		fmt.Fprintf(w, "%s", f)
 	}
 }
 

--- a/cmd/describe/core/node.go
+++ b/cmd/describe/core/node.go
@@ -47,7 +47,7 @@ func describeNode(currentContextPath string, namespace string, args []string) {
 			c := &types.DescribeClient{Namespace: namespace, Interface: fake}
 			d := desc.NodeDescriber{c}
 			out, _ := d.Describe(namespace, _Node.GetName(), desc.DescriberSettings{ShowEvents: false})
-			fmt.Printf(out)
+			fmt.Printf("%s", out)
 		}
 	}
 }

--- a/cmd/describe/core/pod.go
+++ b/cmd/describe/core/pod.go
@@ -44,7 +44,7 @@ func describePod(currentContextPath string, defaultConfigNamespace string, args 
 			c := &types.DescribeClient{Namespace: defaultConfigNamespace, Interface: fake}
 			d := describe.PodDescriber{c}
 			out, _ := d.Describe(defaultConfigNamespace, pod.GetName(), describe.DescriberSettings{ShowEvents: false})
-			fmt.Printf(out)
+			fmt.Printf("%s", out)
 		}
 	}
 }

--- a/cmd/upgrade/helpers.go
+++ b/cmd/upgrade/helpers.go
@@ -43,7 +43,7 @@ func updateOmcExecutable(omcExecutablePath string, url string, desiredVersion st
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("error: Expected status code 200 requesting " + url + ", received " + strconv.Itoa(resp.StatusCode))
+		return fmt.Errorf("error: Expected status code 200 requesting %s, received ", strconv.Itoa(resp.StatusCode))
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Go 1.24 introduces stricter checks for format string validation. This commit fixes instances where non-constant format strings were used in calls to functions like `fmt.Errorf`, `fmt.Printf`, and similar.

~~~
$ go version
go version go1.24rc2 linux/amd64

$ go vet -printf ./...
# github.com/gmeghnag/omc/cmd/upgrade
cmd/upgrade/helpers.go:46:21: non-constant format string in call to fmt.Errorf
# github.com/gmeghnag/omc/cmd/certs
# [github.com/gmeghnag/omc/cmd/certs]
cmd/certs/inspect.go:177:18: non-constant format string in call to fmt.Fprintf
# github.com/gmeghnag/omc/cmd/describe/core
cmd/describe/core/node.go:50:15: non-constant format string in call to fmt.Printf
cmd/describe/core/pod.go:47:15: non-constant format string in call to fmt.Printf

~~~