### PR TITLE
Replace os.Rename() with mv, closes #192

### DIFF
--- a/cmd/upgrade/helpers.go
+++ b/cmd/upgrade/helpers.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -75,10 +76,16 @@ func updateOmcExecutable(omcExecutablePath string, url string, desiredVersion st
 		return err
 	}
 
-	cmd := exec.Command("mv", tempFile.Name(), omcExecutablePath)
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/C", "move", tempFile.Name(), omcExecutablePath)
+	default:
+		cmd = exec.Command("mv", tempFile.Name(), omcExecutablePath)
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("mv command failed: %w\nOutput: %s", err, string(output))
+		return fmt.Errorf("exec mv or move command failed: %w\nOutput: %s", err, string(output))
 	}
 	return nil
 }

--- a/cmd/upgrade/helpers.go
+++ b/cmd/upgrade/helpers.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
+	"os/exec"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
@@ -43,7 +43,7 @@ func updateOmcExecutable(omcExecutablePath string, url string, desiredVersion st
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("error: Expected status code 200 requesting " + url + ", received " + strconv.Itoa(resp.StatusCode))
+		return fmt.Errorf("error: Expected status code 200 requesting %s, received %d", url, resp.StatusCode)
 	}
 	defer resp.Body.Close()
 
@@ -75,9 +75,10 @@ func updateOmcExecutable(omcExecutablePath string, url string, desiredVersion st
 		return err
 	}
 
-	err = os.Rename(tempFile.Name(), omcExecutablePath)
+	cmd := exec.Command("mv", tempFile.Name(), omcExecutablePath)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("mv command failed: %w\nOutput: %s", err, string(output))
 	}
 	return nil
 }


### PR DESCRIPTION
Replacing os.Rename() with mv might hurt Non-Unix compatiblity, by looking at the Releases, omc doesn't support Windows platform. Comparing to adding fallback functions to Open, Copy and Delete, simply using mv perhaps to be an easy-to-understand solution.