### PR TITLE
Improvements to `omc ovn` commands

### DIFF
--- a/cmd/ovn/hostnetinfo.go
+++ b/cmd/ovn/hostnetinfo.go
@@ -41,7 +41,7 @@ var HostnetinfoCmd = &cobra.Command{
 		_nodes, _ := os.ReadDir(nodesFolderPath)
 
 		var data [][]string
-		var ipv4InHeaders, ipv6InHeaders, gatewayIPInHeaders, primaryIfAddrInHeaders bool
+		var ipv4InHeaders, ipv6InHeaders, gatewayIPInHeaders, primaryIfAddrInHeaders, nodeEncapIPInHeaders bool
 		headers := []string{"HOST/NODE", "ROLE"}
 		for _, f := range _nodes {
 			nodeYamlPath := nodesFolderPath + f.Name()
@@ -153,9 +153,25 @@ var HostnetinfoCmd = &cobra.Command{
 				}
 			}
 
-			// if vars.OutputStringVar == "wide" {
-			// If something is to be displayed only with "wide" output, include here.
-			// }
+			if vars.OutputStringVar == "wide" {
+				nodeEncapIP := ""
+				nodeEncapIPs := Node.ObjectMeta.Annotations["k8s.ovn.org/node-encap-ips"]
+				if nodeEncapIPs != "" {
+					var nodeEncapIPsArray []string
+					if err := yaml.Unmarshal([]byte(nodeEncapIPs), &nodeEncapIPsArray); err != nil {
+						panic(err)
+					}
+					nodeEncapIP = strings.Join(nodeEncapIPsArray, ",")
+				}
+
+				if nodeEncapIP != "" {
+					row = append(row, nodeEncapIP)
+					if !nodeEncapIPInHeaders {
+						headers = append(headers, "HOST ENCAP-IPS")
+						nodeEncapIPInHeaders = true
+					}
+				}
+			}
 			data = append(data, row)
 
 		}

--- a/cmd/ovn/hostnetinfo.go
+++ b/cmd/ovn/hostnetinfo.go
@@ -137,13 +137,13 @@ var HostnetinfoCmd = &cobra.Command{
 			}
 
 			gatewayIP := ""
-			GatewayConfigString := Node.ObjectMeta.Annotations["k8s.ovn.org/l3-gateway-config"]
-			if GatewayConfigString != "" {
-				var GatewayConf GatewayConfig
-				if err := yaml.Unmarshal([]byte(GatewayConfigString), &GatewayConf); err != nil {
+			gatewayConfigString := Node.ObjectMeta.Annotations["k8s.ovn.org/l3-gateway-config"]
+			if gatewayConfigString != "" {
+				var gatewayConf GatewayConfig
+				if err := yaml.Unmarshal([]byte(gatewayConfigString), &gatewayConf); err != nil {
 					panic(err)
 				}
-				gatewayIP = strings.Join(GatewayConf.Default.NextHops, ",")
+				gatewayIP = strings.Join(gatewayConf.Default.NextHops, ",")
 			}
 			if gatewayIP != "" {
 				row = append(row, gatewayIP)

--- a/cmd/ovn/nodeextrainfo.go
+++ b/cmd/ovn/nodeextrainfo.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ovn
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/gmeghnag/omc/cmd/helpers"
+	"github.com/gmeghnag/omc/vars"
+
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var NodeExtraInfoCmd = &cobra.Command{
+	Use:     "extrainfo",
+	Aliases: []string{"node-extrainfo"},
+	Short:   "Retrieve some extra information OVN-Kubernetes needs to store about nodes.",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		nodesFolderPath := vars.MustGatherRootPath + "/cluster-scoped-resources/core/nodes/"
+		_nodes, _ := os.ReadDir(nodesFolderPath)
+
+		var data [][]string
+		var nodeIdInHeaders, nodeChassisIdInHeaders, nodeZoneNameInHeaders, nodeRemoteZoneMigratedInHeaders bool
+		headers := []string{"HOST/NODE", "ROLE"}
+		for _, f := range _nodes {
+			nodeYamlPath := nodesFolderPath + f.Name()
+			_file := helpers.ReadYaml(nodeYamlPath)
+			Node := corev1.Node{}
+			if err := yaml.Unmarshal([]byte(_file), &Node); err != nil {
+				fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+nodeYamlPath)
+				os.Exit(1)
+			}
+			//ROLE
+			var NodeRoles []string
+			NodeRole := ""
+			for i := range Node.ObjectMeta.Labels {
+				if strings.HasPrefix(i, "node-role.kubernetes.io/") {
+					s := strings.Split(i, "/")
+					NodeRoles = append(NodeRoles, s[1])
+				}
+			}
+			slices.Sort(NodeRoles)
+			NodeRole = strings.Join(NodeRoles, ",")
+
+			row := []string{Node.Name, NodeRole}
+
+			nodeId := Node.ObjectMeta.Annotations["k8s.ovn.org/node-id"]
+			if nodeId != "" {
+				row = append(row, nodeId)
+				if !nodeIdInHeaders {
+					headers = append(headers, "NODE ID")
+					nodeIdInHeaders = true
+				}
+			}
+
+			nodeChassisId := Node.ObjectMeta.Annotations["k8s.ovn.org/node-chassis-id"]
+			if nodeChassisId != "" {
+				row = append(row, nodeChassisId)
+				if !nodeChassisIdInHeaders {
+					headers = append(headers, "NODE CHASSIS-ID")
+					nodeChassisIdInHeaders = true
+				}
+			}
+
+			if vars.OutputStringVar == "wide" {
+
+				nodeZoneName := Node.ObjectMeta.Annotations["k8s.ovn.org/zone-name"]
+				if nodeZoneName != "" {
+					row = append(row, nodeZoneName)
+					if !nodeZoneNameInHeaders {
+						headers = append(headers, "NODE ZONE-NAME")
+						nodeZoneNameInHeaders = true
+					}
+				}
+
+				nodeRemoteZoneMigrated := Node.ObjectMeta.Annotations["k8s.ovn.org/remote-zone-migrated"]
+				if nodeRemoteZoneMigrated != "" {
+					row = append(row, nodeRemoteZoneMigrated)
+					if !nodeRemoteZoneMigratedInHeaders {
+						headers = append(headers, "NODE REMOTE-ZONE-MIGRATED")
+						nodeRemoteZoneMigratedInHeaders = true
+					}
+				}
+			}
+			data = append(data, row)
+
+		}
+		helpers.PrintTable(headers, data)
+	},
+}
+
+func init() {
+	NodeExtraInfoCmd.Flags().StringVarP(&vars.OutputStringVar, "output", "o", "", "Output format: wide.")
+}

--- a/cmd/ovn/ovn.go
+++ b/cmd/ovn/ovn.go
@@ -36,5 +36,6 @@ func init() {
 	OvnCmd.AddCommand(
 		SubnetsCmd,
 		HostnetinfoCmd,
+		NodeExtraInfoCmd,
 	)
 }


### PR DESCRIPTION
- Improvements in `omc ovn subnets`
  - Moved gateway router IP out of `-o wide` and updated to support the annotation used in current versions
  - Added column to show transit switch IPs
  - Added column to `-o wide` to display the masquerade subnets.

- Improvements in `omc ovn hostnetinfo`
  - Added `node-encap-ips` as `-o wide` column
  - Fixed minor variable naming issue

- Added `omc ovn extrainfo` command for other OVN-Kubernetes information that doesn't easily fall into some category
  - At the moment it includes the chassis-id, the node-id as normal columns, and the zone and remote-zone-migrated columns as `-o wide` (these are not included on default output because they are only relevant on the migration to interconnected OVNK in 4.14).