### PR TITLE
Etcd new commands

### DIFF
--- a/cmd/etcd/alarm.go
+++ b/cmd/etcd/alarm.go
@@ -16,27 +16,22 @@ limitations under the License.
 package etcd
 
 import (
-	"os"
+	"github.com/gmeghnag/omc/vars"
 
 	"github.com/spf13/cobra"
 )
 
-// etcdCmd represents the etcd command
-var Etcd = &cobra.Command{
-	Use:     "etcd",
-	Aliases: []string{"etcdctl"},
-	Short:   "Shows etcd health and status.",
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-		os.Exit(0)
-	},
+func etcdAlarmCommand(currentContextPath string) {
+	etcdFolderPath := currentContextPath + "/etcd_info/"
+	AlarmList(etcdFolderPath)
 }
 
-func init() {
-	Etcd.AddCommand(
-		Health,
-		Status,
-		Members,
-		Alarm,
-	)
+// etcdCmd represents the etcd command
+var Alarm = &cobra.Command{
+	Use:     "alarm",
+	Short:   "Etcd alarm list",
+	Aliases: []string{"alarm-list", "alarms"},
+	Run: func(cmd *cobra.Command, args []string) {
+		etcdAlarmCommand(vars.MustGatherRootPath)
+	},
 }

--- a/cmd/etcd/etcdctl.go
+++ b/cmd/etcd/etcdctl.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -38,7 +37,7 @@ type memberList struct {
 }
 
 func EndpointStatus(etcdFolderPath string) {
-	_file, _ := ioutil.ReadFile(etcdFolderPath + "endpoint_status.json")
+	_file, _ := os.ReadFile(etcdFolderPath + "endpoint_status.json")
 	var Endpoints []epStatus
 	if err := json.Unmarshal([]byte(_file), &Endpoints); err != nil {
 		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file \""+etcdFolderPath+"endpoint_status.json\":", err.Error())
@@ -69,7 +68,7 @@ func EndpointStatus(etcdFolderPath string) {
 }
 
 func EndpointHealth(etcdFolderPath string) {
-	_file, _ := ioutil.ReadFile(etcdFolderPath + "endpoint_health.json")
+	_file, _ := os.ReadFile(etcdFolderPath + "endpoint_health.json")
 	var healthList []epHealth
 	if err := json.Unmarshal([]byte(_file), &healthList); err != nil {
 		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file \""+etcdFolderPath+"endpoint_status.json\":", err.Error())
@@ -92,7 +91,7 @@ func EndpointHealth(etcdFolderPath string) {
 }
 
 func MemberList(etcdFolderPath string) {
-	_file, _ := ioutil.ReadFile(etcdFolderPath + "member_list.json")
+	_file, _ := os.ReadFile(etcdFolderPath + "member_list.json")
 	var memberList memberList
 	if err := json.Unmarshal([]byte(_file), &memberList); err != nil {
 		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file \""+etcdFolderPath+"member_list.json\":", err.Error())

--- a/cmd/etcd/etcdctl.go
+++ b/cmd/etcd/etcdctl.go
@@ -12,7 +12,7 @@ import (
 	etcdserverpb "go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
-type Endpoint struct {
+type epStatus struct {
 	Endpoint string                      `json:"Endpoint"`
 	Resp     etcdserverpb.StatusResponse `json:"Status"`
 }
@@ -39,7 +39,7 @@ type memberList struct {
 
 func EndpointStatus(etcdFolderPath string) {
 	_file, _ := ioutil.ReadFile(etcdFolderPath + "endpoint_status.json")
-	var Endpoints []Endpoint
+	var Endpoints []epStatus
 	if err := json.Unmarshal([]byte(_file), &Endpoints); err != nil {
 		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file \""+etcdFolderPath+"endpoint_status.json\":", err.Error())
 		os.Exit(1)

--- a/cmd/etcd/etcdctl.go
+++ b/cmd/etcd/etcdctl.go
@@ -24,6 +24,19 @@ type epHealth struct {
 	Error  string `json:"error,omitempty"`
 }
 
+type member struct {
+	ID   uint64 `json:"id"` // from https://github.com/etcd-io/etcd/blob/main/client/pkg/types/id.go#L25C9-L25C15
+	Name string `json:"name,omitempty"`
+	//Status is not a field but just "started" unles Name is zero-length as per https://github.com/etcd-io/etcd/blob/4601818f511478980725a215e814e56fb8ee31ef/etcdctl/ctlv3/command/printer.go#L188-L191
+	ClientURLs []string `json:"clientURLs,omitempty"`
+	PeerURLs   []string `json:"peerURLs"`
+	IsLearner  bool     `json:"isLearner,omitempty"`
+}
+
+type memberList struct {
+	Members []member `json:"members"`
+}
+
 func EndpointStatus(etcdFolderPath string) {
 	_file, _ := ioutil.ReadFile(etcdFolderPath + "endpoint_status.json")
 	var Endpoints []Endpoint
@@ -70,6 +83,39 @@ func EndpointHealth(etcdFolderPath string) {
 			fmt.Sprintf("%v", h.Health),
 			h.Took,
 			h.Error,
+		})
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(hdr)
+	table.AppendBulk(rows)
+	table.Render()
+}
+
+func MemberList(etcdFolderPath string) {
+	_file, _ := ioutil.ReadFile(etcdFolderPath + "member_list.json")
+	var memberList memberList
+	if err := json.Unmarshal([]byte(_file), &memberList); err != nil {
+		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file \""+etcdFolderPath+"member_list.json\":", err.Error())
+		os.Exit(1)
+	}
+	var rows [][]string
+	var hdr = []string{"ID", "status", "name", "peer addrs", "client addrs", "is learner"}
+	for _, m := range memberList.Members {
+		status := "started"
+		if len(m.Name) == 0 {
+			status = "unstarted"
+		}
+		isLearner := "false"
+		if m.IsLearner {
+			isLearner = "true"
+		}
+		rows = append(rows, []string{
+			fmt.Sprintf("%x", m.ID),
+			status,
+			m.Name,
+			strings.Join(m.PeerURLs, ","),
+			strings.Join(m.ClientURLs, ","),
+			isLearner,
 		})
 	}
 	table := tablewriter.NewWriter(os.Stdout)

--- a/cmd/etcd/memberlist.go
+++ b/cmd/etcd/memberlist.go
@@ -16,26 +16,22 @@ limitations under the License.
 package etcd
 
 import (
-	"os"
+	"github.com/gmeghnag/omc/vars"
 
 	"github.com/spf13/cobra"
 )
 
-// etcdCmd represents the etcd command
-var Etcd = &cobra.Command{
-	Use:     "etcd",
-	Aliases: []string{"etcdctl"},
-	Short:   "Shows etcd health and status.",
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-		os.Exit(0)
-	},
+func etcdMembersCommand(currentContextPath string) {
+	etcdFolderPath := currentContextPath + "/etcd_info/"
+	MemberList(etcdFolderPath)
 }
 
-func init() {
-	Etcd.AddCommand(
-		Health,
-		Status,
-		Members,
-	)
+// etcdCmd represents the etcd command
+var Members = &cobra.Command{
+	Use:     "members",
+	Aliases: []string{"memberlist", "member-list"},
+	Short:   "Etcd member list",
+	Run: func(cmd *cobra.Command, args []string) {
+		etcdMembersCommand(vars.MustGatherRootPath)
+	},
 }


### PR DESCRIPTION
This PR:
- Adds `omc etcd members` command to display etcd members information available in must-gather.
- Adds `omc etcd alarm` to display etcd alarm information in must-gather.
- Does some minor cleanup improvements in other parts of `omc etcd` code.