### PR TITLE
kwown-types/known-resources: add from api-resources in k8s 1.34

### DIFF
--- a/cmd/get/know-types.go
+++ b/cmd/get/know-types.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
 	"k8s.io/kubernetes/pkg/apis/apps"
+	"k8s.io/kubernetes/pkg/apis/authentication"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	batch "k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/certificates"
@@ -21,9 +22,10 @@ import (
 	"k8s.io/kubernetes/pkg/apis/resource"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	networkingv1_28 "k8s.io/kubernetes/v1_28/pkg/apis/networking"
-        policyv1_28 "k8s.io/kubernetes/v1_28/pkg/apis/policy"
-        resourcev1_30 "k8s.io/kubernetes/v1_30/pkg/apis/resource"
+	policyv1_28 "k8s.io/kubernetes/v1_28/pkg/apis/policy"
+	resourcev1_30 "k8s.io/kubernetes/v1_30/pkg/apis/resource"
 
+	eventsv1 "k8s.io/api/events/v1"
 	discovery "k8s.io/kubernetes/pkg/apis/discovery"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
 
@@ -122,6 +124,16 @@ func addCoordinationTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
+func addAuthenticationTypes(scheme *runtime.Scheme) error {
+	GroupVersion := schema.GroupVersion{Group: "authentication.k8s.io", Version: "v1"}
+	types := []runtime.Object{
+		&authentication.SelfSubjectReview{},
+		&authentication.TokenReview{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
 func addAppsV1Types(scheme *runtime.Scheme) error {
 	GroupVersion := schema.GroupVersion{Group: "apps.openshift.io", Version: "v1"}
 	types := []runtime.Object{
@@ -208,10 +220,29 @@ func addFlowControlV1B2Types(scheme *runtime.Scheme) error {
 	return nil
 }
 
+func addFlowControlV1Types(scheme *runtime.Scheme) error {
+	GroupVersion := schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1"}
+	types := []runtime.Object{
+		&flowcontrol.FlowSchema{},
+		&flowcontrol.PriorityLevelConfiguration{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
 func addDiscoveryTypes(scheme *runtime.Scheme) error {
 	GroupVersion := schema.GroupVersion{Group: "discovery.k8s.io", Version: "v1"}
 	types := []runtime.Object{
 		&discovery.EndpointSlice{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
+func addEventsV1Types(scheme *runtime.Scheme) error {
+	GroupVersion := schema.GroupVersion{Group: "events.k8s.io", Version: "v1"}
+	types := []runtime.Object{
+		&eventsv1.Event{},
 	}
 	scheme.AddKnownTypes(GroupVersion, types...)
 	return nil
@@ -236,7 +267,9 @@ func addNetworkingTypes(scheme *runtime.Scheme) error {
 		&networkingv1_28.ClusterCIDR{},
 		&networking.IngressClass{},
 		&networking.Ingress{},
+		&networking.IPAddress{},
 		&networking.NetworkPolicy{},
+		&networking.ServiceCIDR{},
 	}
 	scheme.AddKnownTypes(GroupVersion, types...)
 	return nil
@@ -305,7 +338,9 @@ func addStorageV1Types(scheme *runtime.Scheme) error {
 		&storage.StorageClass{},
 		&storage.CSINode{},
 		&storage.CSIDriver{},
+		&storage.CSIStorageCapacity{},
 		&storage.VolumeAttachment{},
+		&storage.VolumeAttributesClass{},
 	}
 	scheme.AddKnownTypes(GroupVersion, types...)
 	return nil
@@ -326,6 +361,18 @@ func addResourceV1A2Types(scheme *runtime.Scheme) error {
 		&resourcev1_30.ResourceClass{},
 		&resource.ResourceClaim{},
 		&resource.ResourceClaimTemplate{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
+func addResourceV1Types(scheme *runtime.Scheme) error {
+	GroupVersion := schema.GroupVersion{Group: "resource.k8s.io", Version: "v1"}
+	types := []runtime.Object{
+		&resource.DeviceClass{},
+		&resource.ResourceClaim{},
+		&resource.ResourceClaimTemplate{},
+		&resource.ResourceSlice{},
 	}
 	scheme.AddKnownTypes(GroupVersion, types...)
 	return nil

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -173,6 +173,16 @@ ev:
   name: event
   namespaced: true
   plural: events
+events.events.k8s.io:
+  group: events.k8s.io
+  name: event
+  namespaced: true
+  plural: events
+event.events.k8s.io:
+  group: events.k8s.io
+  name: event
+  namespaced: true
+  plural: events
 limitrange:
   group: core
   name: limitrange
@@ -378,6 +388,26 @@ validatingwebhookconfigurations:
   name: validatingwebhookconfiguration
   namespaced: false
   plural: validatingwebhookconfigurations
+validatingadmissionpolicy:
+  group: admissionregistration.k8s.io
+  name: validatingadmissionpolicy
+  namespaced: false
+  plural: validatingadmissionpolicies
+validatingadmissionpolicies:
+  group: admissionregistration.k8s.io
+  name: validatingadmissionpolicy
+  namespaced: false
+  plural: validatingadmissionpolicies
+validatingadmissionpolicybinding:
+  group: admissionregistration.k8s.io
+  name: validatingadmissionpolicybinding
+  namespaced: false
+  plural: validatingadmissionpolicybindings
+validatingadmissionpolicybindings:
+  group: admissionregistration.k8s.io
+  name: validatingadmissionpolicybinding
+  namespaced: false
+  plural: validatingadmissionpolicybindings
 customresourcedefinition:
   group: apiextensions.k8s.io
   name: customresourcedefinition
@@ -578,6 +608,16 @@ tokenreviews:
   name: tokenreview
   namespaced: false
   plural: tokenreviews
+selfsubjectreview:
+  group: authentication.k8s.io
+  name: selfsubjectreview
+  namespaced: false
+  plural: selfsubjectreviews
+selfsubjectreviews:
+  group: authentication.k8s.io
+  name: selfsubjectreview
+  namespaced: false
+  plural: selfsubjectreviews
 localsubjectaccessreview:
   group: authorization.k8s.io
   name: localsubjectaccessreview
@@ -713,6 +753,31 @@ netpol:
   name: networkpolicy
   namespaced: true
   plural: networkpolicies
+ipaddress:
+  group: networking.k8s.io
+  name: ipaddress
+  namespaced: false
+  plural: ipaddresses
+ipaddresses:
+  group: networking.k8s.io
+  name: ipaddress
+  namespaced: false
+  plural: ipaddresses
+ip:
+  group: networking.k8s.io
+  name: ipaddress
+  namespaced: false
+  plural: ipaddresses
+servicecidr:
+  group: networking.k8s.io
+  name: servicecidr
+  namespaced: false
+  plural: servicecidrs
+servicecidrs:
+  group: networking.k8s.io
+  name: servicecidr
+  namespaced: false
+  plural: servicecidrs
 runtimeclass:
   group: node.k8s.io
   name: runtimeclass
@@ -778,6 +843,46 @@ pc:
   name: priorityclass
   namespaced: false
   plural: priorityclasses
+deviceclass:
+  group: resource.k8s.io
+  name: deviceclass
+  namespaced: false
+  plural: deviceclasses
+deviceclasses:
+  group: resource.k8s.io
+  name: deviceclass
+  namespaced: false
+  plural: deviceclasses
+resourceclaim:
+  group: resource.k8s.io
+  name: resourceclaim
+  namespaced: true
+  plural: resourceclaims
+resourceclaims:
+  group: resource.k8s.io
+  name: resourceclaim
+  namespaced: true
+  plural: resourceclaims
+resourceclaimtemplate:
+  group: resource.k8s.io
+  name: resourceclaimtemplate
+  namespaced: true
+  plural: resourceclaimtemplates
+resourceclaimtemplates:
+  group: resource.k8s.io
+  name: resourceclaimtemplate
+  namespaced: true
+  plural: resourceclaimtemplates
+resourceslice:
+  group: resource.k8s.io
+  name: resourceslice
+  namespaced: false
+  plural: resourceslices
+resourceslices:
+  group: resource.k8s.io
+  name: resourceslice
+  namespaced: false
+  plural: resourceslices
 csidriver:
   group: storage.k8s.io
   name: csidriver
@@ -833,6 +938,21 @@ volumeattachments:
   name: volumeattachment
   namespaced: false
   plural: volumeattachments
+volumeattributesclass:
+  group: storage.k8s.io
+  name: volumeattributesclass
+  namespaced: false
+  plural: volumeattributesclasses
+volumeattributesclasses:
+  group: storage.k8s.io
+  name: volumeattributesclass
+  namespaced: false
+  plural: volumeattributesclasses
+vac:
+  group: storage.k8s.io
+  name: volumeattributesclass
+  namespaced: false
+  plural: volumeattributesclasses
 horizontalpodautoscalers:
   group: autoscaling
   name: horizontalpodautoscaler


### PR DESCRIPTION
👋 Ciao Gabriel, thanks for the project!!
I've seen there are some "new" native k8s types that are missing from the known types.
I captured a snapshot of those from k8s 1.34 and added the missing ones here.

Here is what I used to get them:
```
# spun up a kind cluster
$ kind create cluster --image kindest/node:v1.34.2

# issued a api-resources
$ kubectl --context kind-kind api-resources
NAME                                SHORTNAMES   APIVERSION                        NAMESPACED   KIND
bindings                                         v1                                true         Binding
componentstatuses                   cs           v1                                false        ComponentStatus
configmaps                          cm           v1                                true         ConfigMap
endpoints                           ep           v1                                true         Endpoints
events                              ev           v1                                true         Event
limitranges                         limits       v1                                true         LimitRange
namespaces                          ns           v1                                false        Namespace
nodes                               no           v1                                false        Node
persistentvolumeclaims              pvc          v1                                true         PersistentVolumeClaim
persistentvolumes                   pv           v1                                false        PersistentVolume
pods                                po           v1                                true         Pod
podtemplates                                     v1                                true         PodTemplate
replicationcontrollers              rc           v1                                true         ReplicationController
resourcequotas                      quota        v1                                true         ResourceQuota
secrets                                          v1                                true         Secret
serviceaccounts                     sa           v1                                true         ServiceAccount
services                            svc          v1                                true         Service
mutatingwebhookconfigurations                    admissionregistration.k8s.io/v1   false        MutatingWebhookConfiguration
validatingadmissionpolicies                      admissionregistration.k8s.io/v1   false        ValidatingAdmissionPolicy
validatingadmissionpolicybindings                admissionregistration.k8s.io/v1   false        ValidatingAdmissionPolicyBinding
validatingwebhookconfigurations                  admissionregistration.k8s.io/v1   false        ValidatingWebhookConfiguration
customresourcedefinitions           crd,crds     apiextensions.k8s.io/v1           false        CustomResourceDefinition
apiservices                                      apiregistration.k8s.io/v1         false        APIService
controllerrevisions                              apps/v1                           true         ControllerRevision
daemonsets                          ds           apps/v1                           true         DaemonSet
deployments                         deploy       apps/v1                           true         Deployment
replicasets                         rs           apps/v1                           true         ReplicaSet
statefulsets                        sts          apps/v1                           true         StatefulSet
selfsubjectreviews                               authentication.k8s.io/v1          false        SelfSubjectReview
tokenreviews                                     authentication.k8s.io/v1          false        TokenReview
localsubjectaccessreviews                        authorization.k8s.io/v1           true         LocalSubjectAccessReview
selfsubjectaccessreviews                         authorization.k8s.io/v1           false        SelfSubjectAccessReview
selfsubjectrulesreviews                          authorization.k8s.io/v1           false        SelfSubjectRulesReview
subjectaccessreviews                             authorization.k8s.io/v1           false        SubjectAccessReview
horizontalpodautoscalers            hpa          autoscaling/v2                    true         HorizontalPodAutoscaler
cronjobs                            cj           batch/v1                          true         CronJob
jobs                                             batch/v1                          true         Job
certificatesigningrequests          csr          certificates.k8s.io/v1            false        CertificateSigningRequest
leases                                           coordination.k8s.io/v1            true         Lease
endpointslices                                   discovery.k8s.io/v1               true         EndpointSlice
events                              ev           events.k8s.io/v1                  true         Event
flowschemas                                      flowcontrol.apiserver.k8s.io/v1   false        FlowSchema
prioritylevelconfigurations                      flowcontrol.apiserver.k8s.io/v1   false        PriorityLevelConfiguration
ingressclasses                                   networking.k8s.io/v1              false        IngressClass
ingresses                           ing          networking.k8s.io/v1              true         Ingress
ipaddresses                         ip           networking.k8s.io/v1              false        IPAddress
networkpolicies                     netpol       networking.k8s.io/v1              true         NetworkPolicy
servicecidrs                                     networking.k8s.io/v1              false        ServiceCIDR
runtimeclasses                                   node.k8s.io/v1                    false        RuntimeClass
poddisruptionbudgets                pdb          policy/v1                         true         PodDisruptionBudget
clusterrolebindings                              rbac.authorization.k8s.io/v1      false        ClusterRoleBinding
clusterroles                                     rbac.authorization.k8s.io/v1      false        ClusterRole
rolebindings                                     rbac.authorization.k8s.io/v1      true         RoleBinding
roles                                            rbac.authorization.k8s.io/v1      true         Role
deviceclasses                                    resource.k8s.io/v1                false        DeviceClass
resourceclaims                                   resource.k8s.io/v1                true         ResourceClaim
resourceclaimtemplates                           resource.k8s.io/v1                true         ResourceClaimTemplate
resourceslices                                   resource.k8s.io/v1                false        ResourceSlice
priorityclasses                     pc           scheduling.k8s.io/v1              false        PriorityClass
csidrivers                                       storage.k8s.io/v1                 false        CSIDriver
csinodes                                         storage.k8s.io/v1                 false        CSINode
csistoragecapacities                             storage.k8s.io/v1                 true         CSIStorageCapacity
storageclasses                      sc           storage.k8s.io/v1                 false        StorageClass
volumeattachments                                storage.k8s.io/v1                 false        VolumeAttachment
volumeattributesclasses             vac          storage.k8s.io/v1                 false        VolumeAttributesClass
```

Tested with:

```
[~/src/omc git:(add-native-k8s-api-resources-from-k8s-1.34)] $ ./omc get validatingadmissionpolicy
NAME                                    VALIDATIONS   PARAMKIND                          AGE
default-network-annotation              1             <unset>                            2h
machine-api-machine-vap                 5             cluster.x-k8s.io/v1beta1/Machine   2h
servicecidrs.openshift.io               1             <unset>                            2h
user-defined-networks-namespace-label   1             <unset>                            2h
```

PS. in the files there is some other formatting diff, that's because my editor did the standard go fmt formatting automatically, which was missing from the file.