### PR TITLE
Add better completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 GUIDE.md
 TEST
 omc
+omc-test
 .DS_Store
 **/.DS_Store
 omc-darwin-amd64
@@ -8,3 +9,13 @@ omc-linux-amd64
 omc-win-amd64
 cmd/describe/apps
 .vscode/launch.json
+
+# Build directories
+build/
+dist/
+coverage/
+
+# Completion scripts (generated)
+*.bash
+*.zsh
+*.fish

--- a/COMPLETION.md
+++ b/COMPLETION.md
@@ -1,0 +1,156 @@
+# Shell Completion Guide
+
+`omc` provides enhanced shell completion support for bash and zsh, making it easier to discover and use resource types without memorizing them.
+
+## Features
+
+The shell completion now supports:
+
+- **Resource type completion** for `omc get` command - suggests resource types like `pod`, `deployment`, `service`, etc.
+- **Resource type completion** for `omc describe` command
+- **Smart filtering** - completions are filtered based on what you've typed
+- **Support for short forms** - works with abbreviations like `po`, `deploy`, `svc`, etc.
+
+## Installation
+
+### Bash
+
+To enable completion for the current session:
+```bash
+source <(omc completion bash)
+```
+
+To enable completion permanently, add to your `~/.bashrc`:
+```bash
+echo 'source <(omc completion bash)' >> ~/.bashrc
+```
+
+Or install to the system-wide completion directory (requires root):
+```bash
+omc completion bash | sudo tee /etc/bash_completion.d/omc > /dev/null
+```
+
+### Zsh
+
+To enable completion for the current session:
+```zsh
+source <(omc completion zsh)
+```
+
+To enable completion permanently, add to your `~/.zshrc`:
+```zsh
+echo 'source <(omc completion zsh)' >> ~/.zshrc
+```
+
+Or for oh-my-zsh users:
+```zsh
+omc completion zsh > "${fpath[1]}/_omc"
+```
+
+After installing, reload your shell or run:
+```zsh
+compinit
+```
+
+## Usage Examples
+
+### Get Command
+
+```bash
+# See all available resource types
+omc get <TAB>
+
+# Filter by prefix - shows pod, pods, po, poddisruptionbudget, etc.
+omc get po<TAB>
+
+# Works with common abbreviations
+omc get dep<TAB>      # shows deploy, deployment, deployments, deploymentconfig, deploymentconfigs
+omc get svc<TAB>      # shows svc, service, services
+omc get cm<TAB>       # shows cm, configmap, configmaps
+```
+
+### Describe Command
+
+```bash
+# See all describable resource types
+omc describe <TAB>
+
+# Filter by prefix
+omc describe pod<TAB>  # shows pod, pods, po
+omc describe node<TAB> # shows node, nodes, no
+```
+
+## Supported Resource Types
+
+The completion system supports all Kubernetes and OpenShift resource types, including:
+
+**Core Resources:**
+- pods (po), services (svc), nodes (no), namespaces (ns)
+- configmaps (cm), secrets, serviceaccounts (sa)
+- persistentvolumes (pv), persistentvolumeclaims (pvc)
+- endpoints (ep), events (ev)
+
+**Workload Resources:**
+- deployments (deploy), replicasets (rs), statefulsets (sts)
+- daemonsets (ds), jobs, cronjobs (cj)
+- replicationcontrollers (rc)
+
+**OpenShift Resources:**
+- deploymentconfigs (dc), buildconfigs (bc), builds
+- routes, projects, imagestreams, imagestreamtags
+- templates
+
+**Networking:**
+- ingresses (ing), networkpolicies (netpol)
+- services (svc), endpoints (ep)
+
+**Storage:**
+- storageclasses (sc), persistentvolumes (pv), persistentvolumeclaims (pvc)
+- volumeattachments, csidrivers, csinodes
+
+**RBAC:**
+- roles, rolebindings, clusterroles, clusterrolebindings
+- serviceaccounts (sa)
+
+**And many more...**
+
+## Comparison with kubectl/oc
+
+Unlike `kubectl` and `oc` which provide basic flag completion, `omc` now provides:
+
+1. **Positional argument completion** - suggests resource types at the right position
+2. **Context-aware suggestions** - only suggests valid resource types for each command
+3. **Full alias support** - all common short forms are included
+
+## Troubleshooting
+
+### Completions not working
+
+1. Make sure you've sourced the completion script:
+   ```bash
+   source <(omc completion bash)  # for bash
+   source <(omc completion zsh)   # for zsh
+   ```
+
+2. For zsh, ensure `compinit` has been called after loading the completion
+
+3. Verify completion is loaded:
+   ```bash
+   complete -p omc  # for bash
+   which _omc       # for zsh
+   ```
+
+### Completions are slow
+
+The completion system reads from the embedded resource list, so performance should be instant. If you experience slowness, it may be due to other completions in your shell.
+
+## Development
+
+The completion functions are defined in:
+- `cmd/get/completion.go` - completion for get command
+- `cmd/describe/completion.go` - completion for describe command
+
+To add completion for a new command:
+1. Create a `ValidArgsFunction` that returns the list of valid arguments
+2. Add the function to the command definition using `ValidArgsFunction: YourCompletionFunc`
+3. Return `cobra.ShellCompDirectiveNoFileComp` to prevent file completion

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,325 @@
+# Makefile for omc (OpenShift Must-Gather CLI)
+
+# Project variables
+PROJECT_NAME := omc
+BINARY_NAME := omc
+PACKAGE := github.com/gmeghnag/omc
+
+# Version information
+VERSION_TAG ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION_HASH ?= $(shell git log -n1 --pretty=format:%h 2>/dev/null || echo "unknown")
+LDFLAGS := -X '$(PACKAGE)/vars.OMCVersionTag=$(VERSION_TAG)' -X '$(PACKAGE)/vars.OMCVersionHash=$(VERSION_HASH)'
+
+# Build variables
+GO := go
+GOFLAGS := -v
+BUILD_FLAGS := -ldflags "$(LDFLAGS)"
+CGO_ENABLED ?= 0
+
+# Directories
+BUILD_DIR := build
+DIST_DIR := dist
+COVERAGE_DIR := coverage
+
+# Platforms for cross-compilation
+PLATFORMS := \
+	linux/amd64 \
+	linux/arm64 \
+	darwin/amd64 \
+	darwin/arm64 \
+	windows/amd64
+
+# Test variables
+TEST_TIMEOUT := 10m
+COVERAGE_PROFILE := $(COVERAGE_DIR)/coverage.out
+COVERAGE_HTML := $(COVERAGE_DIR)/coverage.html
+
+.PHONY: all
+all: clean deps build test ## Build and test the project (default target)
+
+.PHONY: help
+help: ## Display this help message
+	@echo "$(PROJECT_NAME) - Available targets:"
+	@awk 'BEGIN {FS = ":.*##"; printf "\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-20s %s\n", $$1, $$2 } /^##@/ { printf "\n%s\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Build targets
+
+.PHONY: build
+build: ## Build the binary for the current platform
+	@echo "Building $(BINARY_NAME)..."
+	@mkdir -p $(BUILD_DIR)
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GOFLAGS) $(BUILD_FLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) .
+	@echo "Binary built: $(BUILD_DIR)/$(BINARY_NAME)"
+
+.PHONY: build-all
+build-all: ## Build binaries for all platforms
+	@echo "Building for all platforms..."
+	@mkdir -p $(DIST_DIR)
+	@$(foreach platform,$(PLATFORMS), \
+		$(call build_platform,$(platform)); \
+	)
+	@echo "All binaries built in $(DIST_DIR)/"
+
+.PHONY: install
+install: build ## Install the binary to GOPATH/bin or /usr/local/bin
+	@echo "Installing $(BINARY_NAME)..."
+	@if [ -n "$(GOPATH)" ] && [ -d "$(GOPATH)/bin" ]; then \
+		cp $(BUILD_DIR)/$(BINARY_NAME) $(GOPATH)/bin/; \
+		echo "Installed to $(GOPATH)/bin/$(BINARY_NAME)"; \
+	else \
+		sudo cp $(BUILD_DIR)/$(BINARY_NAME) /usr/local/bin/; \
+		echo "Installed to /usr/local/bin/$(BINARY_NAME)"; \
+	fi
+
+.PHONY: uninstall
+uninstall: ## Uninstall the binary from GOPATH/bin or /usr/local/bin
+	@echo "Uninstalling $(BINARY_NAME)..."
+	@if [ -n "$(GOPATH)" ] && [ -f "$(GOPATH)/bin/$(BINARY_NAME)" ]; then \
+		rm -f $(GOPATH)/bin/$(BINARY_NAME); \
+		echo "Removed from $(GOPATH)/bin/$(BINARY_NAME)"; \
+	elif [ -f "/usr/local/bin/$(BINARY_NAME)" ]; then \
+		sudo rm -f /usr/local/bin/$(BINARY_NAME); \
+		echo "Removed from /usr/local/bin/$(BINARY_NAME)"; \
+	else \
+		echo "No installed binary found"; \
+	fi
+
+##@ Test targets
+
+.PHONY: test
+test: ## Run unit tests
+	@echo "Running tests..."
+	$(GO) test -v -timeout $(TEST_TIMEOUT) ./...
+	@echo "All tests passed"
+
+.PHONY: test-short
+test-short: ## Run unit tests (short mode)
+	@echo "Running tests (short mode)..."
+	$(GO) test -short -v ./...
+
+.PHONY: test-race
+test-race: ## Run tests with race detector
+	@echo "Running tests with race detector..."
+	$(GO) test -race -v -timeout $(TEST_TIMEOUT) ./...
+
+.PHONY: test-coverage
+test-coverage: ## Run tests with coverage report
+	@echo "Running tests with coverage..."
+	@mkdir -p $(COVERAGE_DIR)
+	$(GO) test -v -timeout $(TEST_TIMEOUT) -coverprofile=$(COVERAGE_PROFILE) -covermode=atomic ./...
+	@echo "Coverage profile generated: $(COVERAGE_PROFILE)"
+
+.PHONY: coverage-html
+coverage-html: test-coverage ## Generate HTML coverage report
+	@echo "Generating HTML coverage report..."
+	$(GO) tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)
+	@echo "HTML coverage report: $(COVERAGE_HTML)"
+
+.PHONY: coverage-func
+coverage-func: test-coverage ## Show function-level coverage
+	@$(GO) tool cover -func=$(COVERAGE_PROFILE)
+
+.PHONY: bench
+bench: ## Run benchmarks
+	@echo "Running benchmarks..."
+	$(GO) test -bench=. -benchmem ./...
+
+##@ Code quality targets
+
+.PHONY: fmt
+fmt: ## Format Go code
+	@echo "Formatting code..."
+	$(GO) fmt ./...
+	@echo "Code formatted"
+
+.PHONY: fmt-check
+fmt-check: ## Check if code is formatted
+	@echo "Checking code formatting..."
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "The following files are not formatted:"; \
+		gofmt -l .; \
+		exit 1; \
+	fi
+	@echo "All files are formatted"
+
+.PHONY: vet
+vet: ## Run go vet
+	@echo "Running go vet..."
+	$(GO) vet ./...
+	@echo "No issues found"
+
+.PHONY: lint
+lint: ## Run golangci-lint (requires golangci-lint to be installed)
+	@echo "Running linter..."
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run --timeout=5m; \
+		echo "Linting completed"; \
+	else \
+		echo "golangci-lint not installed. Install with:"; \
+		echo "  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
+	fi
+
+.PHONY: staticcheck
+staticcheck: ## Run staticcheck (requires staticcheck to be installed)
+	@echo "Running staticcheck..."
+	@if command -v staticcheck >/dev/null 2>&1; then \
+		staticcheck ./...; \
+		echo "Staticcheck completed"; \
+	else \
+		echo "staticcheck not installed. Install with:"; \
+		echo "  go install honnef.co/go/tools/cmd/staticcheck@latest"; \
+	fi
+
+.PHONY: check
+check: fmt-check vet ## Run all code quality checks
+
+##@ Dependency targets
+
+.PHONY: deps
+deps: ## Download dependencies
+	@echo "Downloading dependencies..."
+	$(GO) mod download
+	@echo "Dependencies downloaded"
+
+.PHONY: deps-tidy
+deps-tidy: ## Tidy and verify dependencies
+	@echo "Tidying dependencies..."
+	$(GO) mod tidy
+	$(GO) mod verify
+	@echo "Dependencies tidied"
+
+.PHONY: deps-vendor
+deps-vendor: ## Vendor dependencies
+	@echo "Vendoring dependencies..."
+	$(GO) mod vendor
+	@echo "Dependencies vendored"
+
+.PHONY: deps-update
+deps-update: ## Update all dependencies
+	@echo "Updating dependencies..."
+	$(GO) get -u ./...
+	$(GO) mod tidy
+	@echo "Dependencies updated"
+
+##@ Release targets
+
+.PHONY: release
+release: clean check test build-all dist ## Create a release (build, test, package)
+	@echo "Release build complete"
+
+.PHONY: dist
+dist: ## Create distribution archives
+	@echo "Creating distribution archives..."
+	@mkdir -p $(DIST_DIR)
+	@cd $(DIST_DIR) && \
+	for binary in omc-*; do \
+		if [ -f "$$binary" ]; then \
+			platform=$$(echo $$binary | sed 's/omc-//'); \
+			if echo "$$binary" | grep -q windows; then \
+				zip "$${binary}.zip" "$$binary"; \
+			else \
+				tar -czf "$${binary}.tar.gz" "$$binary"; \
+			fi; \
+		fi; \
+	done
+	@echo "Distribution archives created in $(DIST_DIR)/"
+
+.PHONY: checksums
+checksums: ## Generate checksums for release files
+	@echo "Generating checksums..."
+	@cd $(DIST_DIR) && \
+	find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec md5sum {} \; | tee checksums.txt
+	@echo "Checksums generated: $(DIST_DIR)/checksums.txt"
+
+##@ Cleanup targets
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	@echo "Cleaning build artifacts..."
+	@rm -rf $(BUILD_DIR) $(DIST_DIR) $(COVERAGE_DIR)
+	@rm -f $(BINARY_NAME) omc-test
+	@echo "Clean complete"
+
+.PHONY: clean-all
+clean-all: clean ## Remove all generated files including vendor
+	@echo "Removing vendor directory..."
+	@rm -rf vendor
+
+##@ Development targets
+
+.PHONY: run
+run: build ## Build and run the application
+	@echo "Running $(BINARY_NAME)..."
+	@$(BUILD_DIR)/$(BINARY_NAME)
+
+.PHONY: dev
+dev: ## Run in development mode (with race detector)
+	@echo "Running in development mode..."
+	$(GO) run -race .
+
+.PHONY: watch
+watch: ## Watch for changes and rebuild (requires entr)
+	@if command -v entr >/dev/null 2>&1; then \
+		echo "Watching for changes..."; \
+		find . -name "*.go" | entr -r make build; \
+	else \
+		echo "entr not installed. Install with your package manager."; \
+	fi
+
+##@ Completion targets
+
+.PHONY: completion-bash
+completion-bash: build ## Generate bash completion script
+	@echo "Generating bash completion..."
+	@$(BUILD_DIR)/$(BINARY_NAME) completion bash > $(BUILD_DIR)/completion.bash
+	@echo "Bash completion: $(BUILD_DIR)/completion.bash"
+	@echo "  Install with: source $(BUILD_DIR)/completion.bash"
+
+.PHONY: completion-zsh
+completion-zsh: build ## Generate zsh completion script
+	@echo "Generating zsh completion..."
+	@$(BUILD_DIR)/$(BINARY_NAME) completion zsh > $(BUILD_DIR)/completion.zsh
+	@echo "Zsh completion: $(BUILD_DIR)/completion.zsh"
+	@echo "  Install with: source $(BUILD_DIR)/completion.zsh"
+
+.PHONY: completion-fish
+completion-fish: build ## Generate fish completion script
+	@echo "Generating fish completion..."
+	@$(BUILD_DIR)/$(BINARY_NAME) completion fish > $(BUILD_DIR)/completion.fish
+	@echo "Fish completion: $(BUILD_DIR)/completion.fish"
+
+##@ Information targets
+
+.PHONY: version
+version: ## Display version information
+	@echo "Version Tag:  $(VERSION_TAG)"
+	@echo "Version Hash: $(VERSION_HASH)"
+	@echo "Go Version:   $$($(GO) version)"
+
+.PHONY: info
+info: ## Display project information
+	@echo "Project Information:"
+	@echo "  Name:         $(PROJECT_NAME)"
+	@echo "  Package:      $(PACKAGE)"
+	@echo "  Version Tag:  $(VERSION_TAG)"
+	@echo "  Version Hash: $(VERSION_HASH)"
+	@echo "  Go Version:   $$($(GO) version)"
+	@echo "  Build Dir:    $(BUILD_DIR)"
+	@echo "  Dist Dir:     $(DIST_DIR)"
+
+.PHONY: list-tests
+list-tests: ## List all test files
+	@echo "Test files:"
+	@find . -name "*_test.go" -not -path "./vendor/*" | sed 's|^\./||'
+
+# Helper function to build for a specific platform
+define build_platform
+	$(eval GOOS := $(word 1,$(subst /, ,$(1))))
+	$(eval GOARCH := $(word 2,$(subst /, ,$(1))))
+	$(eval OUTPUT := $(DIST_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH)$(if $(filter windows,$(GOOS)),.exe,))
+	@echo "Building for $(GOOS)/$(GOARCH)..."
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 $(GO) build $(BUILD_FLAGS) -o $(OUTPUT) .
+endef
+
+# Default goal when no target is specified
+.DEFAULT_GOAL := all

--- a/cmd/admin/admin.go
+++ b/cmd/admin/admin.go
@@ -23,7 +23,7 @@ import (
 
 // etcdCmd represents the etcd command
 var Admin = &cobra.Command{
-	Use:     "adm",
+	Use: "adm",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 		os.Exit(0)

--- a/cmd/admin/upgrade-recommend.go
+++ b/cmd/admin/upgrade-recommend.go
@@ -43,7 +43,7 @@ func admUpgradeRecommendCommand(currentContextPath string) error {
 		if err := yaml.Unmarshal([]byte(_file), &cv); err != nil {
 			fmt.Println("Error trying to unmarshal file: " + clusterVersionFilePath)
 			os.Exit(1)
-		} 
+		}
 	}
 	if cv.Spec.Channel != "" {
 		if cv.Spec.Upstream == "" {
@@ -114,7 +114,6 @@ func admUpgradeRecommendCommand(currentContextPath string) error {
 
 	//
 	//
-	
 
 	if len(majorMinorBuckets) == 0 {
 		fmt.Fprintf(os.Stdout, "No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.\n")
@@ -185,9 +184,8 @@ func admUpgradeRecommendCommand(currentContextPath string) error {
 	return nil
 }
 
-
 var UpgradeRecommend = &cobra.Command{
-	Use:   "recommend",
+	Use: "recommend",
 	Run: func(cmd *cobra.Command, args []string) {
 		admUpgradeRecommendCommand(vars.MustGatherRootPath)
 	},
@@ -197,7 +195,6 @@ func init() {
 	UpgradeRecommend.PersistentFlags().BoolVar(&showOutdatedReleases, "show-outdated-releases", false, "")
 	UpgradeRecommend.PersistentFlags().BoolVar(&quiet, "quiet", false, "")
 }
-
 
 func notRecommendedCondition(update configv1.ConditionalUpdate) *metav1.Condition {
 	if len(update.Risks) == 0 {
@@ -222,8 +219,6 @@ func notRecommendedCondition(update configv1.ConditionalUpdate) *metav1.Conditio
 		Message: fmt.Sprintf("Conditional update to %s has risks (%s), but no conditions.", update.Release.Version, strings.Join(risks, ", ")),
 	}
 }
-
-
 
 func injectUpgradeableAsCondition(version string, condition *configv1.ClusterOperatorStatusCondition, majorMinorBuckets map[uint64]map[uint64][]configv1.ConditionalUpdate) error {
 	current, err := semver.Parse(version)
@@ -254,7 +249,6 @@ func injectUpgradeableAsCondition(version string, condition *configv1.ClusterOpe
 
 	return nil
 }
-
 
 func ensureUpgradeableRisk(target configv1.ConditionalUpdate, condition *configv1.ClusterOperatorStatusCondition, upgradeableURI string) configv1.ConditionalUpdate {
 	if hasUpgradeableRisk(target, condition) {

--- a/cmd/admin/upgrade.go
+++ b/cmd/admin/upgrade.go
@@ -34,7 +34,6 @@ import (
 
 var IncludeNotRecommended bool
 
-
 func admUpgradeCommand(currentContextPath string) {
 	cv := configv1.ClusterVersion{}
 	clusterVersionFilePath := currentContextPath + "/cluster-scoped-resources/config.openshift.io/clusterversions/version.yaml"
@@ -44,7 +43,7 @@ func admUpgradeCommand(currentContextPath string) {
 		if err := yaml.Unmarshal([]byte(_file), &cv); err != nil {
 			fmt.Println("Error trying to unmarshal file: " + clusterVersionFilePath)
 			os.Exit(1)
-		} 
+		}
 	}
 	if cv.Spec.Channel != "" {
 		if cv.Spec.Upstream == "" {
@@ -60,10 +59,10 @@ func admUpgradeCommand(currentContextPath string) {
 	}
 	if len(cv.Status.AvailableUpdates) > 0 {
 		fmt.Fprintf(os.Stdout, "\nRecommended updates:\n\n")
-			// set the minimal cell width to 14 to have a larger space between the columns for shorter versions
+		// set the minimal cell width to 14 to have a larger space between the columns for shorter versions
 		w := tabwriter.NewWriter(os.Stdout, 14, 2, 1, ' ', 0)
 		fmt.Fprintf(w, "  VERSION\tIMAGE\n")
-			// TODO: add metadata about version
+		// TODO: add metadata about version
 		sortReleasesBySemanticVersions(cv.Status.AvailableUpdates)
 		for _, update := range cv.Status.AvailableUpdates {
 			fmt.Fprintf(w, "  %s\t%s\n", update.Version, update.Image)
@@ -93,7 +92,7 @@ func admUpgradeCommand(currentContextPath string) {
 		} else {
 			fmt.Fprintf(os.Stdout, "\nNo updates which are not recommended based on your cluster configuration are available.\n")
 		}
-    } else if containsNotRecommendedUpdate(cv.Status.ConditionalUpdates) {
+	} else if containsNotRecommendedUpdate(cv.Status.ConditionalUpdates) {
 		qualifier := ""
 		for _, upgrade := range cv.Status.ConditionalUpdates {
 			if c := findCondition(upgrade.Conditions, "Recommended"); c != nil && c.Status != metav1.ConditionTrue && c.Status != metav1.ConditionFalse {
@@ -105,20 +104,19 @@ func admUpgradeCommand(currentContextPath string) {
 	}
 }
 
-
 var Upgrade = &cobra.Command{
-	Use:   "upgrade",
+	Use: "upgrade",
 	Run: func(cmd *cobra.Command, args []string) {
 		admUpgradeCommand(vars.MustGatherRootPath)
 	},
 }
+
 func init() {
 	Upgrade.AddCommand(
 		UpgradeRecommend,
 	)
 	Upgrade.PersistentFlags().BoolVar(&IncludeNotRecommended, "include-not-recommended", false, "Display additional updates which are not recommended based on your cluster configuration.")
 }
-
 
 // sortConditionalUpdatesBySemanticVersions sorts the input slice in decreasing order.
 func sortConditionalUpdatesBySemanticVersions(updates []configv1.ConditionalUpdate) {
@@ -138,7 +136,6 @@ func sortConditionalUpdatesBySemanticVersions(updates []configv1.ConditionalUpda
 	})
 }
 
-
 func findCondition(conditions []metav1.Condition, name string) *metav1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == name {
@@ -155,8 +152,6 @@ func containsNotRecommendedUpdate(updates []configv1.ConditionalUpdate) bool {
 	}
 	return false
 }
-
-
 
 // sortReleasesBySemanticVersions sorts the input slice in decreasing order.
 func sortReleasesBySemanticVersions(versions []configv1.Release) {

--- a/cmd/completion/resources.go
+++ b/cmd/completion/resources.go
@@ -1,0 +1,174 @@
+package completion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gmeghnag/omc/vars"
+	"sigs.k8s.io/yaml"
+)
+
+// KindGroupNamespacedFunc is a function type for resolving resource metadata
+type KindGroupNamespacedFunc func(string) (string, string, string, bool, error)
+
+// GetResourceNames returns a list of resource names for the given resource type
+// The kindGroupNamespacedFunc parameter should be get.KindGroupNamespaced
+func GetResourceNames(resourceType, toComplete string, kindGroupNamespacedFunc KindGroupNamespacedFunc) []string {
+	var completions []string
+
+	// Check if we have a must-gather path configured
+	if vars.MustGatherRootPath == "" {
+		return completions
+	}
+
+	// Determine the resource plural, group, and whether it's namespaced
+	resourceNamePlural, resourceGroup, _, namespaced, err := kindGroupNamespacedFunc(resourceType)
+	if err != nil {
+		return completions
+	}
+
+	// Get namespace from flag or use current namespace
+	namespace := vars.Namespace
+	if namespace == "" {
+		namespace = vars.DefaultProject
+	}
+
+	var resourceNames []string
+
+	if namespaced {
+		// For namespaced resources
+		if namespace != "" {
+			// Get resources from specific namespace
+			resourceNames = getResourceNamesFromNamespace(resourceNamePlural, resourceGroup, namespace, toComplete)
+		} else {
+			// Get resources from all namespaces
+			resourceNames = getResourceNamesFromAllNamespaces(resourceNamePlural, resourceGroup, toComplete)
+		}
+	} else {
+		// For cluster-scoped resources
+		resourceNames = getClusterScopedResourceNames(resourceNamePlural, resourceGroup, toComplete)
+	}
+
+	return resourceNames
+}
+
+// getResourceNamesFromNamespace gets resource names from a specific namespace
+func getResourceNamesFromNamespace(resourcePlural, resourceGroup, namespace, toComplete string) []string {
+	var names []string
+
+	resourcesPath := fmt.Sprintf("%s/namespaces/%s/%s/%s.yaml", vars.MustGatherRootPath, namespace, resourceGroup, resourcePlural)
+
+	// Try reading the aggregated file first
+	if fileInfo, err := os.Stat(resourcesPath); err == nil && fileInfo.Size() > 0 {
+		names = extractResourceNamesFromFile(resourcesPath, toComplete)
+	} else {
+		// Try reading individual files from directory
+		resourceDir := fmt.Sprintf("%s/namespaces/%s/%s/%s", vars.MustGatherRootPath, namespace, resourceGroup, resourcePlural)
+		names = extractResourceNamesFromDir(resourceDir, toComplete)
+	}
+
+	return names
+}
+
+// getResourceNamesFromAllNamespaces gets resource names from all namespaces
+func getResourceNamesFromAllNamespaces(resourcePlural, resourceGroup, toComplete string) []string {
+	var names []string
+	seen := make(map[string]bool)
+
+	namespacesPath := fmt.Sprintf("%s/namespaces", vars.MustGatherRootPath)
+	namespaces, err := os.ReadDir(namespacesPath)
+	if err != nil {
+		return names
+	}
+
+	for _, ns := range namespaces {
+		if !ns.IsDir() {
+			continue
+		}
+
+		nsNames := getResourceNamesFromNamespace(resourcePlural, resourceGroup, ns.Name(), toComplete)
+		for _, name := range nsNames {
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+
+	return names
+}
+
+// getClusterScopedResourceNames gets cluster-scoped resource names
+func getClusterScopedResourceNames(resourcePlural, resourceGroup, toComplete string) []string {
+	var names []string
+
+	resourcesPath := fmt.Sprintf("%s/cluster-scoped-resources/%s/%s.yaml", vars.MustGatherRootPath, resourceGroup, resourcePlural)
+
+	// Try reading the aggregated file first
+	if fileInfo, err := os.Stat(resourcesPath); err == nil && fileInfo.Size() > 0 {
+		names = extractResourceNamesFromFile(resourcesPath, toComplete)
+	} else {
+		// Try reading individual files from directory
+		resourceDir := fmt.Sprintf("%s/cluster-scoped-resources/%s/%s", vars.MustGatherRootPath, resourceGroup, resourcePlural)
+		names = extractResourceNamesFromDir(resourceDir, toComplete)
+	}
+
+	return names
+}
+
+// extractResourceNamesFromFile extracts resource names from a YAML file containing a list
+func extractResourceNamesFromFile(filePath, toComplete string) []string {
+	var names []string
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return names
+	}
+
+	// Parse as a list
+	var resourceList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+
+	if err := yaml.Unmarshal(data, &resourceList); err != nil {
+		return names
+	}
+
+	for _, item := range resourceList.Items {
+		if item.Metadata.Name != "" && strings.HasPrefix(item.Metadata.Name, toComplete) {
+			names = append(names, item.Metadata.Name)
+		}
+	}
+
+	return names
+}
+
+// extractResourceNamesFromDir extracts resource names from individual YAML files in a directory
+func extractResourceNamesFromDir(dirPath, toComplete string) []string {
+	var names []string
+
+	files, err := os.ReadDir(dirPath)
+	if err != nil {
+		return names
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		// Extract name from filename (usually <name>.yaml)
+		name := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
+		if strings.HasPrefix(name, toComplete) {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}

--- a/cmd/describe/completion.go
+++ b/cmd/describe/completion.go
@@ -1,0 +1,62 @@
+package describe
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// DescribeResourceCompletionFunc provides completion for resource types
+func DescribeResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+	
+	// If we already have an argument, don't offer more resource types
+	// (we're now completing resource names, which we can't do with must-gather)
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Common resources that are describable
+	commonResources := []string{
+		"pod", "pods", "po",
+		"node", "nodes", "no",
+		"service", "services", "svc",
+		"deployment", "deployments", "deploy",
+		"replicaset", "replicasets", "rs",
+		"statefulset", "statefulsets", "sts",
+		"daemonset", "daemonsets", "ds",
+		"job", "jobs",
+		"cronjob", "cronjobs", "cj",
+		"namespace", "namespaces", "ns",
+		"persistentvolume", "persistentvolumes", "pv",
+		"persistentvolumeclaim", "persistentvolumeclaims", "pvc",
+		"configmap", "configmaps", "cm",
+		"secret", "secrets",
+		"serviceaccount", "serviceaccounts", "sa",
+		"ingress", "ingresses", "ing",
+		"networkpolicy", "networkpolicies", "netpol",
+		"storageclass", "storageclasses", "sc",
+		"clusterrole", "clusterroles",
+		"clusterrolebinding", "clusterrolebindings",
+		"role", "roles",
+		"rolebinding", "rolebindings",
+		"deploymentconfig", "deploymentconfigs", "dc",
+		"buildconfig", "buildconfigs", "bc",
+		"build", "builds",
+		"route", "routes",
+		"project", "projects",
+		"imagestream", "imagestreams",
+		"horizontalpodautoscaler", "horizontalpodautoscalers", "hpa",
+		"endpoints", "ep",
+		"event", "events", "ev",
+		"replicationcontroller", "replicationcontrollers", "rc",
+	}
+
+	for _, resource := range commonResources {
+		if strings.HasPrefix(resource, strings.ToLower(toComplete)) {
+			completions = append(completions, resource)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/describe/completion.go
+++ b/cmd/describe/completion.go
@@ -9,7 +9,7 @@ import (
 // DescribeResourceCompletionFunc provides completion for resource types
 func DescribeResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var completions []string
-	
+
 	// If we already have an argument, don't offer more resource types
 	// (we're now completing resource names, which we can't do with must-gather)
 	if len(args) > 0 {

--- a/cmd/describe/completion.go
+++ b/cmd/describe/completion.go
@@ -3,17 +3,19 @@ package describe
 import (
 	"strings"
 
+	"github.com/gmeghnag/omc/cmd/completion"
+	"github.com/gmeghnag/omc/cmd/get"
 	"github.com/spf13/cobra"
 )
 
-// DescribeResourceCompletionFunc provides completion for resource types
+// DescribeResourceCompletionFunc provides completion for resource types and resource names
 func DescribeResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var completions []string
 
-	// If we already have an argument, don't offer more resource types
-	// (we're now completing resource names, which we can't do with must-gather)
+	// If we already have a resource type argument, complete resource names
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		resourceType := args[0]
+		return completion.GetResourceNames(resourceType, toComplete, get.KindGroupNamespaced), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Common resources that are describable

--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -28,8 +28,9 @@ import (
 
 // DescribeCmd represents the describe command
 var DescribeCmd = &cobra.Command{
-	Use: "describe",
-	Short: "Show details of a specific resource or group of resources",
+	Use:               "describe",
+	Short:             "Show details of a specific resource or group of resources",
+	ValidArgsFunction: DescribeResourceCompletionFunc,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Help()

--- a/cmd/etcd/etcdctl_test.go
+++ b/cmd/etcd/etcdctl_test.go
@@ -1,114 +1,113 @@
 package etcd
 
 import (
-    "testing"
-    "os"
-    "bytes"
-    "fmt"
-    "io"
-    "strconv"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"testing"
 )
 
-
 func TestEndpointStatus(t *testing.T) {
-    testData := createHealthyETCDStatus()
-    endpoints := []string{"https://192.168.50.11:2379", "https://192.168.50.10:2379", "https://192.168.50.12:2379"}
-    memberIDsDec := []string{"2509054861951574500", "7258754974466672000", "7656230591208016000"}
-    memberIDsHex, err := decimalToHex(memberIDsDec)
-    if err != nil {
-        t.Fatal(err)
-    }
+	testData := createHealthyETCDStatus()
+	endpoints := []string{"https://192.168.50.11:2379", "https://192.168.50.10:2379", "https://192.168.50.12:2379"}
+	memberIDsDec := []string{"2509054861951574500", "7258754974466672000", "7656230591208016000"}
+	memberIDsHex, err := decimalToHex(memberIDsDec)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    // Mock a temporary file with test data
-    tmpfile, err := os.Create("/tmp/endpoint_status.json")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer os.Remove(tmpfile.Name()) 
-    if _, err := tmpfile.Write([]byte(testData)); err != nil {
-        t.Fatal(err)
-    }
-    if err := tmpfile.Close(); err != nil {
-        t.Fatal(err)
-    }
+	// Mock a temporary file with test data
+	tmpfile, err := os.Create("/tmp/endpoint_status.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(testData)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
 
-    // Redirect stdout to a buffer
-    old := os.Stdout
-    r, w, _ := os.Pipe()
-    os.Stdout = w
-    EndpointStatus("/tmp/")
-    w.Close()
-    os.Stdout = old
-    var output bytes.Buffer
-    io.Copy(&output, r)
-    r.Close()
+	// Redirect stdout to a buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	EndpointStatus("/tmp/")
+	w.Close()
+	os.Stdout = old
+	var output bytes.Buffer
+	io.Copy(&output, r)
+	r.Close()
 
-    for _, endpoint := range endpoints {
-        if !bytes.Contains(output.Bytes(), []byte(endpoint)) {
-            t.Errorf("endpoint %q is missing from the output", endpoint)
-        }
-    }
+	for _, endpoint := range endpoints {
+		if !bytes.Contains(output.Bytes(), []byte(endpoint)) {
+			t.Errorf("endpoint %q is missing from the output", endpoint)
+		}
+	}
 
-    for _, memberIDHex := range memberIDsHex {
-        if !bytes.Contains(output.Bytes(), []byte(memberIDHex)) {
-            t.Errorf("member ID %q is missing from the output", memberIDHex)
-        }
-    }
+	for _, memberIDHex := range memberIDsHex {
+		if !bytes.Contains(output.Bytes(), []byte(memberIDHex)) {
+			t.Errorf("member ID %q is missing from the output", memberIDHex)
+		}
+	}
 }
 
 func TestEndpointHealth(t *testing.T) {
-    testData := createHealthyETCDHealth()
-    endpoints := []string{"https://192.168.50.11:2379", "https://192.168.50.10:2379", "https://192.168.50.12:2379"}
+	testData := createHealthyETCDHealth()
+	endpoints := []string{"https://192.168.50.11:2379", "https://192.168.50.10:2379", "https://192.168.50.12:2379"}
 
-    // Mock a temporary file with test data
-    tmpfile, err := os.Create("/tmp/endpoint_health.json")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer os.Remove(tmpfile.Name()) 
-    if _, err := tmpfile.Write([]byte(testData)); err != nil {
-        t.Fatal(err)
-    }
-    if err := tmpfile.Close(); err != nil {
-        t.Fatal(err)
-    }
+	// Mock a temporary file with test data
+	tmpfile, err := os.Create("/tmp/endpoint_health.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write([]byte(testData)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
 
-    // Redirect stdout to a buffer
-    old := os.Stdout
-    r, w, _ := os.Pipe()
-    os.Stdout = w
-    EndpointHealth("/tmp/")
-    w.Close()
-    os.Stdout = old
-    var output bytes.Buffer
-    io.Copy(&output, r)
-    r.Close()
+	// Redirect stdout to a buffer
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	EndpointHealth("/tmp/")
+	w.Close()
+	os.Stdout = old
+	var output bytes.Buffer
+	io.Copy(&output, r)
+	r.Close()
 
-    for _, endpoint := range endpoints {
-        if !bytes.Contains(output.Bytes(), []byte(endpoint)) {
-            t.Errorf("endpoint %q is missing from the output", endpoint)
-        }
-    }
+	for _, endpoint := range endpoints {
+		if !bytes.Contains(output.Bytes(), []byte(endpoint)) {
+			t.Errorf("endpoint %q is missing from the output", endpoint)
+		}
+	}
 }
 
 func decimalToHex(memberIDsDec []string) ([]string, error) {
-    var memberIDsHex []string
+	var memberIDsHex []string
 
-    // Convert each decimal member ID to hexadecimal
-    for _, dec := range memberIDsDec {
-        decInt, err := strconv.ParseUint(dec, 10, 64)
-        if err != nil {
-            return nil, err
-        }
-        hexStr := fmt.Sprintf("%x", decInt)
-        memberIDsHex = append(memberIDsHex, hexStr)
-    }
+	// Convert each decimal member ID to hexadecimal
+	for _, dec := range memberIDsDec {
+		decInt, err := strconv.ParseUint(dec, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hexStr := fmt.Sprintf("%x", decInt)
+		memberIDsHex = append(memberIDsHex, hexStr)
+	}
 
-    return memberIDsHex, nil
+	return memberIDsHex, nil
 }
 
 func createHealthyETCDStatus() string {
-    testData := `[
+	testData := `[
         {
             "Endpoint": "https://192.168.50.11:2379",
             "Status": {
@@ -164,11 +163,11 @@ func createHealthyETCDStatus() string {
             }
         }
     ]`
-    return testData
+	return testData
 }
 
 func createHealthyETCDHealth() string {
-    testData := `[
+	testData := `[
         {
             "endpoint": "https://192.168.50.10:2379",
             "health": true,
@@ -185,5 +184,5 @@ func createHealthyETCDHealth() string {
             "took": "12.666484ms"
         }
     ]`
-    return testData
+	return testData
 }

--- a/cmd/etcd/health.go
+++ b/cmd/etcd/health.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/etcd/status.go
+++ b/cmd/etcd/status.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/get/completion.go
+++ b/cmd/get/completion.go
@@ -3,18 +3,19 @@ package get
 import (
 	"strings"
 
+	"github.com/gmeghnag/omc/cmd/completion"
 	"github.com/gmeghnag/omc/vars"
 	"github.com/spf13/cobra"
 )
 
-// GetResourceCompletionFunc provides completion for resource types
+// GetResourceCompletionFunc provides completion for resource types and resource names
 func GetResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var completions []string
 
-	// If we already have an argument, don't offer more resource types
-	// (we're now completing resource names, which we can't do with must-gather)
+	// If we already have a resource type argument, complete resource names
 	if len(args) > 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		resourceType := args[0]
+		return completion.GetResourceNames(resourceType, toComplete, KindGroupNamespaced), cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// Get all known resource types from vars.KnownResources
@@ -43,7 +44,6 @@ func GetResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete str
 		"cm", "configmap", "configmaps",
 		"secret", "secrets",
 		"sa", "serviceaccount", "serviceaccounts",
-		"deploy", "deployment", "deployments",
 		"ds", "daemonset", "daemonsets",
 		"rs", "replicaset", "replicasets",
 		"sts", "statefulset", "statefulsets",

--- a/cmd/get/completion.go
+++ b/cmd/get/completion.go
@@ -1,0 +1,93 @@
+package get
+
+import (
+	"strings"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+// GetResourceCompletionFunc provides completion for resource types
+func GetResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+	
+	// If we already have an argument, don't offer more resource types
+	// (we're now completing resource names, which we can't do with must-gather)
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Get all known resource types from vars.KnownResources
+	seen := make(map[string]bool)
+	for resourceKey := range vars.KnownResources {
+		resourceLower := strings.ToLower(resourceKey)
+		
+		// Only add if it starts with what user has typed
+		if strings.HasPrefix(resourceLower, strings.ToLower(toComplete)) {
+			if !seen[resourceLower] {
+				seen[resourceLower] = true
+				completions = append(completions, resourceLower)
+			}
+		}
+	}
+
+	// Common short forms that might not be in KnownResources
+	commonShortForms := []string{
+		"po", "pod", "pods",
+		"deploy", "deployment", "deployments",
+		"svc", "service", "services",
+		"ns", "namespace", "namespaces",
+		"no", "node", "nodes",
+		"pv", "persistentvolume", "persistentvolumes",
+		"pvc", "persistentvolumeclaim", "persistentvolumeclaims",
+		"cm", "configmap", "configmaps",
+		"secret", "secrets",
+		"sa", "serviceaccount", "serviceaccounts",
+		"deploy", "deployment", "deployments",
+		"ds", "daemonset", "daemonsets",
+		"rs", "replicaset", "replicasets",
+		"sts", "statefulset", "statefulsets",
+		"job", "jobs",
+		"cj", "cronjob", "cronjobs",
+		"ing", "ingress", "ingresses",
+		"netpol", "networkpolicy", "networkpolicies",
+		"pdb", "poddisruptionbudget", "poddisruptionbudgets",
+		"sc", "storageclass", "storageclasses",
+		"crd", "crds", "customresourcedefinition", "customresourcedefinitions",
+		"clusterrole", "clusterroles",
+		"clusterrolebinding", "clusterrolebindings",
+		"role", "roles",
+		"rolebinding", "rolebindings",
+		"dc", "deploymentconfig", "deploymentconfigs",
+		"bc", "buildconfig", "buildconfigs",
+		"build", "builds",
+		"route", "routes",
+		"project", "projects",
+		"imagestream", "imagestreams",
+		"imagestreamtag", "imagestreamtags",
+		"template", "templates",
+		"hpa", "horizontalpodautoscaler", "horizontalpodautoscalers",
+		"ep", "endpoints",
+		"ev", "event", "events",
+		"rc", "replicationcontroller", "replicationcontrollers",
+		"quota", "resourcequota", "resourcequotas",
+		"limits", "limitrange", "limitranges",
+		"pc", "priorityclass", "priorityclasses",
+		"csr", "certificatesigningrequest", "certificatesigningrequests",
+		"lease", "leases",
+		"endpointslice", "endpointslices",
+		"apiservice", "apiservices",
+		"scc", "securitycontextconstraints",
+	}
+
+	for _, resource := range commonShortForms {
+		if strings.HasPrefix(resource, strings.ToLower(toComplete)) {
+			if !seen[resource] {
+				seen[resource] = true
+				completions = append(completions, resource)
+			}
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/get/completion.go
+++ b/cmd/get/completion.go
@@ -10,7 +10,7 @@ import (
 // GetResourceCompletionFunc provides completion for resource types
 func GetResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	var completions []string
-	
+
 	// If we already have an argument, don't offer more resource types
 	// (we're now completing resource names, which we can't do with must-gather)
 	if len(args) > 0 {
@@ -21,7 +21,7 @@ func GetResourceCompletionFunc(cmd *cobra.Command, args []string, toComplete str
 	seen := make(map[string]bool)
 	for resourceKey := range vars.KnownResources {
 		resourceLower := strings.ToLower(resourceKey)
-		
+
 		// Only add if it starts with what user has typed
 		if strings.HasPrefix(resourceLower, strings.ToLower(toComplete)) {
 			if !seen[resourceLower] {

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -74,8 +74,9 @@ var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
 var yamlData []byte
 
 var GetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
+	Use:               "get",
+	Short:             "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
+	ValidArgsFunction: GetResourceCompletionFunc,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			cmd.Help()

--- a/cmd/logs/completion.go
+++ b/cmd/logs/completion.go
@@ -1,0 +1,144 @@
+package logs
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// LogsCompletionFunc provides completion for pod names
+func LogsCompletionFunc(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var completions []string
+
+	// logs command takes pod name as first argument
+	// If we already have a pod name, no more completions
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Check if we have a must-gather path configured
+	if vars.MustGatherRootPath == "" {
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Get namespace from flag or use default
+	namespace := vars.Namespace
+	if namespace == "" {
+		namespace = vars.DefaultProject
+	}
+
+	// Get pod names from must-gather
+	podNames := getPodNames(namespace, toComplete)
+	return podNames, cobra.ShellCompDirectiveNoFileComp
+}
+
+// getPodNames returns pod names from the must-gather
+func getPodNames(namespace, toComplete string) []string {
+	var podNames []string
+
+	if namespace != "" {
+		// Get pods from specific namespace
+		podNames = getPodsFromNamespace(namespace, toComplete)
+	} else {
+		// Get pods from all namespaces
+		podNames = getPodsFromAllNamespaces(toComplete)
+	}
+
+	return podNames
+}
+
+// getPodsFromNamespace gets pod names from a specific namespace
+func getPodsFromNamespace(namespace, toComplete string) []string {
+	var podNames []string
+	
+	// Check for aggregated pods.yaml file
+	podsFile := filepath.Join(vars.MustGatherRootPath, "namespaces", namespace, "core", "pods.yaml")
+	names := extractPodNamesFromFile(podsFile, toComplete)
+	podNames = append(podNames, names...)
+
+	// Check for individual pod files in pods/ directory
+	podsDir := filepath.Join(vars.MustGatherRootPath, "namespaces", namespace, "core", "pods")
+	names = extractPodNamesFromDir(podsDir, toComplete)
+	podNames = append(podNames, names...)
+
+	return podNames
+}
+
+// getPodsFromAllNamespaces gets pod names from all namespaces
+func getPodsFromAllNamespaces(toComplete string) []string {
+	var podNames []string
+
+	namespacesPath := filepath.Join(vars.MustGatherRootPath, "namespaces")
+	namespaces, err := ioutil.ReadDir(namespacesPath)
+	if err != nil {
+		return podNames
+	}
+
+	for _, ns := range namespaces {
+		if ns.IsDir() {
+			names := getPodsFromNamespace(ns.Name(), toComplete)
+			podNames = append(podNames, names...)
+		}
+	}
+
+	return podNames
+}
+
+// extractPodNamesFromFile extracts pod names from a YAML file containing a list
+func extractPodNamesFromFile(filePath, toComplete string) []string {
+	var podNames []string
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return podNames
+	}
+
+	var podList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `yaml:"name"`
+			} `yaml:"metadata"`
+		} `yaml:"items"`
+	}
+
+	err = yaml.Unmarshal(data, &podList)
+	if err != nil {
+		return podNames
+	}
+
+	for _, pod := range podList.Items {
+		podName := pod.Metadata.Name
+		if strings.HasPrefix(podName, toComplete) {
+			podNames = append(podNames, podName)
+		}
+	}
+
+	return podNames
+}
+
+// extractPodNamesFromDir extracts pod names from individual YAML files in a directory
+func extractPodNamesFromDir(dirPath, toComplete string) []string {
+	var podNames []string
+
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return podNames
+	}
+
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".yaml") {
+			continue
+		}
+
+		podName := strings.TrimSuffix(file.Name(), ".yaml")
+		if strings.HasPrefix(podName, toComplete) {
+			podNames = append(podNames, podName)
+		}
+	}
+
+	return podNames
+}

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -32,8 +32,9 @@ var LogLevel string
 
 // logsCmd represents the logs command
 var Logs = &cobra.Command{
-	Use:   "logs",
-	Short: "Print the logs for a container in a pod",
+	Use:               "logs",
+	Short:             "Print the logs for a container in a pod",
+	ValidArgsFunction: LogsCompletionFunc,
 	Run: func(cmd *cobra.Command, args []string) {
 		if vars.MustGatherRootPath == "" {
 			fmt.Fprintln(os.Stderr, "There are no must-gather resources defined.")

--- a/cmd/machineconfig/diff.go
+++ b/cmd/machineconfig/diff.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/machineconfig/machineconfig.go
+++ b/cmd/machineconfig/machineconfig.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/prometheus/target.go
+++ b/cmd/prometheus/target.go
@@ -76,10 +76,10 @@ type Target struct {
 	ScrapeURL  string `json:"scrapeUrl"`
 	GlobalURL  string `json:"globalUrl"`
 
-	LastError          string              `json:"lastError"`
-	LastScrape         time.Time           `json:"lastScrape"`
-	LastScrapeDuration float64             `json:"lastScrapeDuration"`
-	Health             string              `json:"health"`
+	LastError          string    `json:"lastError"`
+	LastScrape         time.Time `json:"lastScrape"`
+	LastScrapeDuration float64   `json:"lastScrapeDuration"`
+	Health             string    `json:"health"`
 
 	ScrapeInterval string `json:"scrapeInterval"`
 	ScrapeTimeout  string `json:"scrapeTimeout"`

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/testdata/namespaces/default/core/pods.yaml
+++ b/testdata/namespaces/default/core/pods.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: nginx-pod
+    namespace: default
+  spec:
+    containers:
+    - name: nginx
+      image: nginx:latest
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: redis-pod
+    namespace: default
+  spec:
+    containers:
+    - name: redis
+      image: redis:latest
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: postgres-pod
+    namespace: default
+  spec:
+    containers:
+    - name: postgres
+      image: postgres:latest


### PR DESCRIPTION
So `omc` does not currently offer completion for positional arguments such as:

`omc get <pod> <pod_name>`

This PR implements that.  A lot of changes related to whitespace noise is because, we didn't seem to be using `gofmt` standards previously and bunch of files were using four spaces, instead of tab. `gofmt` uses tabs. Let me know if that is an issue. 

Disclaimer: Most of the completion code however was generated by Claude. 
