### PR TITLE
Add support for user.openshift.io resources

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -374,13 +374,34 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 		for _, f := range resourcesFiles {
 			resourceYamlPath := resourceDir + "/" + f.Name()
 			_file, _ := os.ReadFile(resourceYamlPath)
+		var rawList struct {
+			Items []map[string]interface{} `json:"items"`
+		}
+		if err := yaml.Unmarshal(_file, &rawList); err == nil && len(rawList.Items) > 0 {
+			for _, rawItem := range rawList.Items {
+				item := unstructured.Unstructured{Object: rawItem}
+				if item.Object == nil {
+					continue
+				}
+					if vars.SortBy != "" {
+						UnstructuredItems.Items = append(UnstructuredItems.Items, item)
+					} else {
+						if len(resources) > 0 {
+							_, ok := resources[item.GetName()]
+							if ok {
+								handleObject(item)
+							}
+						} else {
+							handleObject(item)
+						}
+					}
+				}
+				continue
+			}
+
 			item := unstructured.Unstructured{}
 			if err := yaml.Unmarshal(_file, &item); err != nil {
 				fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
-				os.Exit(1)
-			}
-			if item.IsList() {
-				fmt.Fprintln(os.Stderr, "error: file \""+resourceYamlPath+"\" contains a \"List\" objectKind, while it should contain a single resource.")
 				os.Exit(1)
 			}
 			if vars.SortBy != "" {

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -374,34 +374,13 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 		for _, f := range resourcesFiles {
 			resourceYamlPath := resourceDir + "/" + f.Name()
 			_file, _ := os.ReadFile(resourceYamlPath)
-		var rawList struct {
-			Items []map[string]interface{} `json:"items"`
-		}
-		if err := yaml.Unmarshal(_file, &rawList); err == nil && len(rawList.Items) > 0 {
-			for _, rawItem := range rawList.Items {
-				item := unstructured.Unstructured{Object: rawItem}
-				if item.Object == nil {
-					continue
-				}
-					if vars.SortBy != "" {
-						UnstructuredItems.Items = append(UnstructuredItems.Items, item)
-					} else {
-						if len(resources) > 0 {
-							_, ok := resources[item.GetName()]
-							if ok {
-								handleObject(item)
-							}
-						} else {
-							handleObject(item)
-						}
-					}
-				}
-				continue
-			}
-
 			item := unstructured.Unstructured{}
 			if err := yaml.Unmarshal(_file, &item); err != nil {
 				fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
+				os.Exit(1)
+			}
+			if item.IsList() {
+				fmt.Fprintln(os.Stderr, "error: file \""+resourceYamlPath+"\" contains a \"List\" objectKind, while it should contain a single resource.")
 				os.Exit(1)
 			}
 			if vars.SortBy != "" {

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -176,6 +176,7 @@ func init() {
 	_ = addStorageV1B1Types(vars.Schema)
 	_ = addTemplateV1Types(vars.Schema)
 	_ = addOAuthV1Types(vars.Schema)
+  _ = addUserV1Types(vars.Schema)
 	utilruntime.Must(schemeBuilder.AddToScheme(vars.Schema))
 
 	vars.TableGenerator = printers.NewTableGenerator()

--- a/cmd/get/know-types.go
+++ b/cmd/get/know-types.go
@@ -38,6 +38,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	securityv1 "github.com/openshift/api/security/v1"
+  userv1 "github.com/openshift/api/user/v1"
 	imagev1 "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	projectv1helpers "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
 	"github.com/openshift/openshift-apiserver/pkg/route/apis/route"
@@ -429,4 +430,15 @@ func addOAuthV1Types(scheme *runtime.Scheme) error {
 	}
 	scheme.AddKnownTypes(GroupVersion, types...)
 	return nil
+}
+
+func addUserV1Types(scheme *runtime.Scheme) error {
+  GroupVersion := schema.GroupVersion{Group: "user.openshift.io", Version: "v1"}                                                                                                                                                        
+  types := []runtime.Object{                                                                                                                                                                                                            
+    &userv1.User{},                                                                                                                                                                                                               
+    &userv1.Group{},                                                                                                                                                                                                              
+    &userv1.Identity{},                                                                                                                                                                                                           
+  }
+  scheme.AddKnownTypes(GroupVersion, types...)                                                                                                                                                                                          
+  return nil
 }

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -998,3 +998,13 @@ users:
   name: user
   namespaced: false
   plural: users
+group:
+  group: user.openshift.io
+  name: group
+  namespaced: false
+  plural: groups
+groups:
+  group: user.openshift.io
+  name: group
+  namespaced: false
+  plural: groups

--- a/cmd/get/known-resources.yaml
+++ b/cmd/get/known-resources.yaml
@@ -978,3 +978,23 @@ oauthclients:
   name: oauthclient
   namespaced: false
   plural: oauthclients
+identities:
+  group: user.openshift.io
+  name: identity
+  namespaced: false
+  plural: identities
+identity:
+  group: user.openshift.io
+  name: identity
+  namespaced: false
+  plural: identities
+user:
+  group: user.openshift.io
+  name: user
+  namespaced: false
+  plural: users
+users:
+  group: user.openshift.io
+  name: user
+  namespaced: false
+  plural: users

--- a/cmd/get/missing-handlers.go
+++ b/cmd/get/missing-handlers.go
@@ -18,28 +18,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kubernetes/pkg/printers"
-  userv1 "github.com/openshift/api/user/v1"
 )
 
 func AddMissingHandlers(h printers.PrintHandler) {
-	userColumnDefinitions := []metav1.TableColumnDefinition{
-		{Name: "Name", Type: "string", Format: "name"},
-		{Name: "UID", Type: "string"},
-		{Name: "Full Name", Type: "string"},
-		{Name: "Identities", Type: "string"},
-	}
-	h.TableHandler(userColumnDefinitions, printUserList)
-	h.TableHandler(userColumnDefinitions, printUser)
-
-	identityColumnDefinitions := []metav1.TableColumnDefinition{
-		{Name: "Name", Type: "string", Format: "name"},
-		{Name: "IDP Name", Type: "string"},
-		{Name: "IDP Username", Type: "string"},
-		{Name: "User Name", Type: "string"},
-		{Name: "User UID", Type: "string"},
-	}
-	h.TableHandler(identityColumnDefinitions, printIdentityList)
-	h.TableHandler(identityColumnDefinitions, printIdentity)
 	apiServiceColumnDefinitions := []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Service", Type: "string"},
@@ -239,53 +220,3 @@ func printOAuthClient(oauthClient *oauthapi.OAuthClient, options printers.Genera
 
 	return []metav1.TableRow{row}, nil
 }
-
-func printUser(obj *userv1.User, options printers.GenerateOptions) ([]metav1.TableRow, error) {
-	row := metav1.TableRow{}
-	row.Cells = append(row.Cells,
-		obj.Name,
-		string(obj.UID),
-		obj.FullName,
-		strings.Join(obj.Identities, ","),
-	)
-	return []metav1.TableRow{row}, nil
-}
-
-func printUserList(list *userv1.UserList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
-	var rows []metav1.TableRow
-	for i := range list.Items {
-		r, err := printUser(&list.Items[i], options)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, r...)
-	}
-	return rows, nil
-}
-
-func printIdentity(obj *userv1.Identity, options printers.GenerateOptions) ([]metav1.TableRow, error) {
-	row := metav1.TableRow{}
-	row.Cells = append(row.Cells,
-		obj.Name,
-		obj.ProviderName,
-		obj.ProviderUserName,
-		obj.User.Name,
-		string(obj.User.UID),
-	)
-	return []metav1.TableRow{row}, nil
-}
-
-func printIdentityList(list *userv1.IdentityList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
-	var rows []metav1.TableRow
-	for i := range list.Items {
-		r, err := printIdentity(&list.Items[i], options)
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, r...)
-	}
-	return rows, nil
-}
-
-
-

--- a/cmd/get/missing-handlers.go
+++ b/cmd/get/missing-handlers.go
@@ -18,9 +18,28 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kubernetes/pkg/printers"
+  userv1 "github.com/openshift/api/user/v1"
 )
 
 func AddMissingHandlers(h printers.PrintHandler) {
+	userColumnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name"},
+		{Name: "UID", Type: "string"},
+		{Name: "Full Name", Type: "string"},
+		{Name: "Identities", Type: "string"},
+	}
+	h.TableHandler(userColumnDefinitions, printUserList)
+	h.TableHandler(userColumnDefinitions, printUser)
+
+	identityColumnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name"},
+		{Name: "IDP Name", Type: "string"},
+		{Name: "IDP Username", Type: "string"},
+		{Name: "User Name", Type: "string"},
+		{Name: "User UID", Type: "string"},
+	}
+	h.TableHandler(identityColumnDefinitions, printIdentityList)
+	h.TableHandler(identityColumnDefinitions, printIdentity)
 	apiServiceColumnDefinitions := []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name"},
 		{Name: "Service", Type: "string"},
@@ -220,3 +239,53 @@ func printOAuthClient(oauthClient *oauthapi.OAuthClient, options printers.Genera
 
 	return []metav1.TableRow{row}, nil
 }
+
+func printUser(obj *userv1.User, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	row := metav1.TableRow{}
+	row.Cells = append(row.Cells,
+		obj.Name,
+		string(obj.UID),
+		obj.FullName,
+		strings.Join(obj.Identities, ","),
+	)
+	return []metav1.TableRow{row}, nil
+}
+
+func printUserList(list *userv1.UserList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	var rows []metav1.TableRow
+	for i := range list.Items {
+		r, err := printUser(&list.Items[i], options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+func printIdentity(obj *userv1.Identity, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	row := metav1.TableRow{}
+	row.Cells = append(row.Cells,
+		obj.Name,
+		obj.ProviderName,
+		obj.ProviderUserName,
+		obj.User.Name,
+		string(obj.User.UID),
+	)
+	return []metav1.TableRow{row}, nil
+}
+
+func printIdentityList(list *userv1.IdentityList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	var rows []metav1.TableRow
+	for i := range list.Items {
+		r, err := printIdentity(&list.Items[i], options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+
+

--- a/pkg/deserializer/deserializer.go
+++ b/pkg/deserializer/deserializer.go
@@ -4,6 +4,7 @@ package deserializer
 import (
 
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  userv1 "github.com/openshift/api/user/v1"
 
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	nodeapi "k8s.io/kubernetes/pkg/apis/node"
@@ -230,6 +231,12 @@ func RawObjectToRuntimeObject(rawObject []byte, schema *runtime.Scheme) runtime.
 		return &template.Template{}
 	case *oauthapi.OAuthClient:
 		return &oauthapi.OAuthClient{}
+  case *userv1.User:
+    return &userv1.User{}
+  case *userv1.Identity:
+    return &userv1.Identity{}
+  case *userv1.Group:
+    return &userv1.Group{}
 	}
 	//fmt.Println("RUNTIME UNKNOW")
 	return &runtime.Unknown{}

--- a/pkg/deserializer/deserializer.go
+++ b/pkg/deserializer/deserializer.go
@@ -46,6 +46,7 @@ import (
 	// cliprint "k8s.io/cli-runtime/pkg/printers"
 	quotav1 "github.com/openshift/api/quota/v1"
 	securityv1 "github.com/openshift/api/security/v1"
+  userv1 "github.com/openshift/api/user/v1"
 	"github.com/openshift/openshift-apiserver/pkg/route/apis/route"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
@@ -230,6 +231,12 @@ func RawObjectToRuntimeObject(rawObject []byte, schema *runtime.Scheme) runtime.
 		return &template.Template{}
 	case *oauthapi.OAuthClient:
 		return &oauthapi.OAuthClient{}
+  case *userv1.User:
+    return &userv1.User{}
+  case *userv1.Group:
+    return &userv1.Group{}
+  case *userv1.Identity:
+    return &userv1.Identity{}
 	}
 	//fmt.Println("RUNTIME UNKNOW")
 	return &runtime.Unknown{}

--- a/pkg/deserializer/deserializer.go
+++ b/pkg/deserializer/deserializer.go
@@ -4,7 +4,6 @@ package deserializer
 import (
 
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  userv1 "github.com/openshift/api/user/v1"
 
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	nodeapi "k8s.io/kubernetes/pkg/apis/node"
@@ -231,12 +230,6 @@ func RawObjectToRuntimeObject(rawObject []byte, schema *runtime.Scheme) runtime.
 		return &template.Template{}
 	case *oauthapi.OAuthClient:
 		return &oauthapi.OAuthClient{}
-  case *userv1.User:
-    return &userv1.User{}
-  case *userv1.Identity:
-    return &userv1.Identity{}
-  case *userv1.Group:
-    return &userv1.Group{}
 	}
 	//fmt.Println("RUNTIME UNKNOW")
 	return &runtime.Unknown{}


### PR DESCRIPTION
This minor change in the `cmd/get/known-resources.yaml` file has the purpose of adding support to get `Users`, `Groups`, and `Identities` resources (from the `user.openshift.io` group) with  the command `omc get`, when those resources are collected with `oc adm inspect groups,users,identities`.