### PR TITLE
feat: add ceph, rados, rbd, ceph-volume and radosgw-admin commands

### DIFF
--- a/cmd/ceph/ceph.go
+++ b/cmd/ceph/ceph.go
@@ -1,0 +1,21 @@
+package ceph
+
+import (
+	"os"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+var Ceph = &cobra.Command{
+	Use:                "ceph [command] [args...]",
+	Short:              "Shows pre-captured Ceph command output from an ODF must-gather.",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+			cmd.Help()
+			os.Exit(0)
+		}
+		LookupAndPrint(vars.MustGatherRootPath, "ceph", args)
+	},
+}

--- a/cmd/ceph/cephvolume.go
+++ b/cmd/ceph/cephvolume.go
@@ -1,0 +1,21 @@
+package ceph
+
+import (
+	"os"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+var CephVolume = &cobra.Command{
+	Use:                "ceph-volume [command] [args...]",
+	Short:              "Shows pre-captured ceph-volume command output from an ODF must-gather.",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+			cmd.Help()
+			os.Exit(0)
+		}
+		LookupAndPrint(vars.MustGatherRootPath, "ceph-volume", args)
+	},
+}

--- a/cmd/ceph/lookup.go
+++ b/cmd/ceph/lookup.go
@@ -1,0 +1,123 @@
+package ceph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func BuildFilename(prefix string, args []string) string {
+	if len(args) == 0 {
+		return prefix
+	}
+	return prefix + "_" + strings.Join(args, "_")
+}
+
+func ParseArgs(args []string) (commandArgs []string, format string) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--output" || arg == "--format" || arg == "-o" {
+			if i+1 < len(args) {
+				format = args[i+1]
+				i++
+				continue
+			}
+		}
+		if strings.HasPrefix(arg, "--output=") {
+			format = strings.TrimPrefix(arg, "--output=")
+			continue
+		}
+		if strings.HasPrefix(arg, "--format=") {
+			format = strings.TrimPrefix(arg, "--format=")
+			continue
+		}
+		if strings.HasPrefix(arg, "-o=") {
+			format = strings.TrimPrefix(arg, "-o=")
+			continue
+		}
+		commandArgs = append(commandArgs, arg)
+	}
+	return
+}
+
+func LookupAndPrint(mustGatherRoot string, prefix string, args []string) {
+	commandArgs, format := ParseArgs(args)
+	filename := BuildFilename(prefix, commandArgs)
+
+	var dir, fullFilename string
+	if format == "json" || format == "json-pretty" {
+		dir = filepath.Join(mustGatherRoot, "ceph", "must_gather_commands_json_output")
+		fullFilename = filename + "_--format_json-pretty"
+	} else {
+		dir = filepath.Join(mustGatherRoot, "ceph", "must_gather_commands")
+		fullFilename = filename
+	}
+
+	filePath := filepath.Join(dir, fullFilename)
+	data, err := os.ReadFile(filePath)
+	if err == nil {
+		fmt.Print(string(data))
+		return
+	}
+
+	// Try alternate filename for "ceph config show <param>" -> "config_<param>"
+	if prefix == "ceph" && len(commandArgs) >= 3 && commandArgs[0] == "config" && commandArgs[1] == "show" {
+		altFilename := "config_" + strings.Join(commandArgs[2:], "_")
+		altPath := filepath.Join(dir, altFilename)
+		data, err = os.ReadFile(altPath)
+		if err == nil {
+			fmt.Print(string(data))
+			return
+		}
+	}
+
+	SuggestCommands(mustGatherRoot, prefix, commandArgs)
+}
+
+func SuggestCommands(mustGatherRoot string, prefix string, args []string) {
+	cmdDir := filepath.Join(mustGatherRoot, "ceph", "must_gather_commands")
+	entries, err := os.ReadDir(cmdDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error: no Ceph data found in this must-gather.")
+		fmt.Fprintln(os.Stderr, "This must-gather may not be from an ODF/OCS cluster.")
+		os.Exit(1)
+	}
+
+	searchPrefix := prefix
+	if len(args) > 0 {
+		searchPrefix = BuildFilename(prefix, args)
+	}
+
+	var suggestions []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, searchPrefix) {
+			suggestions = append(suggestions, FilenameToCommand(name))
+		}
+	}
+	sort.Strings(suggestions)
+
+	if len(args) > 0 {
+		fmt.Fprintf(os.Stderr, "Error: command output not found for: %s\n", prefix+" "+strings.Join(args, " "))
+	} else {
+		fmt.Fprintf(os.Stderr, "Error: no arguments provided.\n")
+	}
+
+	if len(suggestions) > 0 {
+		fmt.Fprintln(os.Stderr, "\nAvailable commands in this must-gather:")
+		for _, s := range suggestions {
+			fmt.Fprintf(os.Stderr, "  omc %s\n", s)
+		}
+	}
+	os.Exit(1)
+}
+
+func FilenameToCommand(filename string) string {
+	name := strings.TrimSuffix(filename, "_--format_json-pretty")
+	return strings.ReplaceAll(name, "_", " ")
+}

--- a/cmd/ceph/lookup_test.go
+++ b/cmd/ceph/lookup_test.go
@@ -1,0 +1,225 @@
+package ceph
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildFilename(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		args   []string
+		want   string
+	}{
+		{"ceph status", "ceph", []string{"status"}, "ceph_status"},
+		{"ceph osd tree", "ceph", []string{"osd", "tree"}, "ceph_osd_tree"},
+		{"ceph osd df tree", "ceph", []string{"osd", "df", "tree"}, "ceph_osd_df_tree"},
+		{"rados lspools", "rados", []string{"lspools"}, "rados_lspools"},
+		{"rbd ls pool", "rbd", []string{"ls", "mypool"}, "rbd_ls_mypool"},
+		{"ceph-volume raw list", "ceph-volume", []string{"raw", "list"}, "ceph-volume_raw_list"},
+		{"radosgw-admin realm list", "radosgw-admin", []string{"realm", "list"}, "radosgw-admin_realm_list"},
+		{"prefix only", "ceph", []string{}, "ceph"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildFilename(tt.prefix, tt.args)
+			if got != tt.want {
+				t.Errorf("BuildFilename(%q, %v) = %q, want %q", tt.prefix, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantArgs   []string
+		wantFormat string
+	}{
+		{"no flags", []string{"osd", "tree"}, []string{"osd", "tree"}, ""},
+		{"--output flag", []string{"status", "--output", "json-pretty"}, []string{"status"}, "json-pretty"},
+		{"--format flag", []string{"status", "--format", "json-pretty"}, []string{"status"}, "json-pretty"},
+		{"-o flag", []string{"status", "-o", "json-pretty"}, []string{"status"}, "json-pretty"},
+		{"--output= form", []string{"status", "--output=json-pretty"}, []string{"status"}, "json-pretty"},
+		{"--format= form", []string{"status", "--format=json-pretty"}, []string{"status"}, "json-pretty"},
+		{"flag in middle", []string{"osd", "tree", "--format", "json-pretty"}, []string{"osd", "tree"}, "json-pretty"},
+		{"empty args", []string{}, nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotArgs, gotFormat := ParseArgs(tt.args)
+			if gotFormat != tt.wantFormat {
+				t.Errorf("ParseArgs(%v) format = %q, want %q", tt.args, gotFormat, tt.wantFormat)
+			}
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Errorf("ParseArgs(%v) args = %v, want %v", tt.args, gotArgs, tt.wantArgs)
+				return
+			}
+			for i := range gotArgs {
+				if gotArgs[i] != tt.wantArgs[i] {
+					t.Errorf("ParseArgs(%v) args[%d] = %q, want %q", tt.args, i, gotArgs[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFilenameToCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{"simple", "ceph_status", "ceph status"},
+		{"multi word", "ceph_osd_tree", "ceph osd tree"},
+		{"strip json suffix", "ceph_status_--format_json-pretty", "ceph status"},
+		{"rados", "rados_lspools", "rados lspools"},
+		{"rbd", "rbd_ls_mypool", "rbd ls mypool"},
+		{"ceph-volume", "ceph-volume_raw_list", "ceph-volume raw list"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilenameToCommand(tt.filename)
+			if got != tt.want {
+				t.Errorf("FilenameToCommand(%q) = %q, want %q", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupAndPrintSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "ceph", "must_gather_commands")
+	if err := os.MkdirAll(cmdDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "test ceph status output\n"
+	if err := os.WriteFile(filepath.Join(cmdDir, "ceph_status"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	LookupAndPrint(tmpDir, "ceph", []string{"status"})
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+
+	if buf.String() != content {
+		t.Errorf("LookupAndPrint output = %q, want %q", buf.String(), content)
+	}
+}
+
+func TestLookupAndPrintJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	jsonDir := filepath.Join(tmpDir, "ceph", "must_gather_commands_json_output")
+	if err := os.MkdirAll(jsonDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `{"status": "HEALTH_OK"}` + "\n"
+	if err := os.WriteFile(filepath.Join(jsonDir, "ceph_status_--format_json-pretty"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	LookupAndPrint(tmpDir, "ceph", []string{"status", "--output", "json-pretty"})
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+
+	if buf.String() != content {
+		t.Errorf("LookupAndPrint JSON output = %q, want %q", buf.String(), content)
+	}
+}
+
+func TestLookupAndPrintConfigShow(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "ceph", "must_gather_commands")
+	if err := os.MkdirAll(cmdDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "config output for osd.0\n"
+	if err := os.WriteFile(filepath.Join(cmdDir, "config_osd.0"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	LookupAndPrint(tmpDir, "ceph", []string{"config", "show", "osd.0"})
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+
+	if buf.String() != content {
+		t.Errorf("LookupAndPrint config show output = %q, want %q", buf.String(), content)
+	}
+}
+
+func TestListAvailableFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmdDir := filepath.Join(tmpDir, "ceph", "must_gather_commands")
+	if err := os.MkdirAll(cmdDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []string{"ceph_status", "ceph_osd_tree", "ceph_osd_df", "rados_lspools", "rbd_ls_pool1"}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(cmdDir, f), []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Capture stderr since SuggestCommands writes there and calls os.Exit
+	// Instead, test the underlying directory listing directly
+	entries, err := os.ReadDir(cmdDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cephFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && len(e.Name()) >= 5 && e.Name()[:5] == "ceph_" {
+			cephFiles = append(cephFiles, e.Name())
+		}
+	}
+
+	if len(cephFiles) != 3 {
+		t.Errorf("Expected 3 ceph files, got %d: %v", len(cephFiles), cephFiles)
+	}
+
+	for _, expected := range []string{"ceph_status", "ceph_osd_tree", "ceph_osd_df"} {
+		found := false
+		for _, f := range cephFiles {
+			if f == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected file %q not found in ceph files: %v", expected, cephFiles)
+		}
+	}
+	fmt.Fprint(io.Discard, cephFiles)
+}

--- a/cmd/ceph/rados.go
+++ b/cmd/ceph/rados.go
@@ -1,0 +1,21 @@
+package ceph
+
+import (
+	"os"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+var Rados = &cobra.Command{
+	Use:                "rados [command] [args...]",
+	Short:              "Shows pre-captured RADOS command output from an ODF must-gather.",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+			cmd.Help()
+			os.Exit(0)
+		}
+		LookupAndPrint(vars.MustGatherRootPath, "rados", args)
+	},
+}

--- a/cmd/ceph/radosgwadmin.go
+++ b/cmd/ceph/radosgwadmin.go
@@ -1,0 +1,21 @@
+package ceph
+
+import (
+	"os"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+var RadosgwAdmin = &cobra.Command{
+	Use:                "radosgw-admin [command] [args...]",
+	Short:              "Shows pre-captured radosgw-admin command output from an ODF must-gather.",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+			cmd.Help()
+			os.Exit(0)
+		}
+		LookupAndPrint(vars.MustGatherRootPath, "radosgw-admin", args)
+	},
+}

--- a/cmd/ceph/rbd.go
+++ b/cmd/ceph/rbd.go
@@ -1,0 +1,21 @@
+package ceph
+
+import (
+	"os"
+
+	"github.com/gmeghnag/omc/vars"
+	"github.com/spf13/cobra"
+)
+
+var Rbd = &cobra.Command{
+	Use:                "rbd [command] [args...]",
+	Short:              "Shows pre-captured RBD command output from an ODF must-gather.",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+			cmd.Help()
+			os.Exit(0)
+		}
+		LookupAndPrint(vars.MustGatherRootPath, "rbd", args)
+	},
+}

--- a/root/root.go
+++ b/root/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gmeghnag/omc/cmd"
 	"github.com/gmeghnag/omc/cmd/admin"
+	"github.com/gmeghnag/omc/cmd/ceph"
 	"github.com/gmeghnag/omc/cmd/certs"
 	"github.com/gmeghnag/omc/cmd/config"
 	"github.com/gmeghnag/omc/cmd/describe"
@@ -92,6 +93,11 @@ func init() {
 	// when this action is called directly.
 	RootCmd.AddCommand(
 		admin.Admin,
+		ceph.Ceph,
+		ceph.CephVolume,
+		ceph.Rados,
+		ceph.RadosgwAdmin,
+		ceph.Rbd,
 		haproxy.Haproxy,
 		certs.Certs,
 		cmd.VersionCmd,


### PR DESCRIPTION
## Summary

- Add support for displaying pre-captured Ceph command outputs from ODF (OpenShift Data Foundation) must-gather archives
- New commands: `omc ceph`, `omc rados`, `omc rbd`, `omc ceph-volume`, `omc radosgw-admin`
- Dynamic passthrough approach - all 80+ captured Ceph commands are automatically accessible without hardcoded mappings
- JSON output support via `--output json-pretty` flag
- Suggestions for available commands when the requested output is not found

Closes #248

## Motivation

The ODF must-gather already collects Ceph CLI outputs as files under `ceph/must_gather_commands/` and `ceph/must_gather_commands_json_output/`, but omc had no way to access them. Users had to manually navigate the must-gather directory structure.

This feature was inspired by a similar implementation in [o-must-gather (omg)](https://github.com/kxr/o-must-gather) v2 branch, which was never officially released (last release v1.2.6, April 2021; project dormant since February 2024). Since omc is the actively maintained tool, this brings the functionality here with an improved approach - dynamic argument-to-filename mapping instead of the limited set of commands omg v2 supported.

## How it works

Arguments are converted to filenames matching the must-gather naming convention:
- `omc ceph status` -> reads `ceph/must_gather_commands/ceph_status`
- `omc ceph osd tree` -> reads `ceph/must_gather_commands/ceph_osd_tree`
- `omc ceph status --output json-pretty` -> reads `ceph/must_gather_commands_json_output/ceph_status_--format_json-pretty`
- `omc ceph config show osd.0` -> reads `ceph/must_gather_commands/config_osd.0` (special case for ODF naming)

When the output file is not found, available commands matching the prefix are listed as suggestions.

## Files changed

| File | Description |
|---|---|
| `cmd/ceph/lookup.go` | Shared logic: filename construction, arg parsing, file lookup, suggestions |
| `cmd/ceph/ceph.go` | `omc ceph` command |
| `cmd/ceph/rados.go` | `omc rados` command |
| `cmd/ceph/rbd.go` | `omc rbd` command |
| `cmd/ceph/cephvolume.go` | `omc ceph-volume` command |
| `cmd/ceph/radosgwadmin.go` | `omc radosgw-admin` command |
| `cmd/ceph/lookup_test.go` | Tests (7 test functions covering all logic) |
| `root/root.go` | Register new commands |

## Test plan

- [x] `go build -v ./...` passes
- [x] `go test -v ./...` passes (all existing + 7 new tests)
- [x] Tested manually against a real ODF must-gather (case 04432224):
  - [x] `omc ceph status` - cluster status output
  - [x] `omc ceph osd tree` - OSD tree
  - [x] `omc ceph status --output json-pretty` - JSON output
  - [x] `omc ceph config show osd.0` - OSD config (special case)
  - [x] `omc rados lspools` - pool listing
  - [x] `omc rbd ls <pool>` - RBD volume listing
  - [x] `omc ceph-volume raw list` - volume raw list
  - [x] `omc radosgw-admin realm list` - RGW realm listing
  - [x] `omc ceph nonexistent` - error with no suggestions
  - [x] `omc ceph osd` - error with matching suggestions
  - [x] `omc ceph` / `omc ceph --help` - help output
  - [x] No regressions in existing commands