### PR TITLE
Fix/get return errors

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -111,8 +111,7 @@ var GetCmd = &cobra.Command{
 				return rerr
 			}
 		}
-		handleOutput(os.Stdout, os.Stderr)
-		return nil
+		return handleOutput(os.Stdout, os.Stderr)
 	},
 }
 
@@ -252,12 +251,15 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 			}
 			for _, item := range UnstructuredItems.Items {
 				if len(resources) > 0 {
-					_, ok := resources[item.GetName()]
-					if ok {
-						handleObject(item)
+					if _, ok := resources[item.GetName()]; ok {
+						if err := handleObject(item); err != nil {
+							return err
+						}
 					}
 				} else {
-					handleObject(item)
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			}
 		} else { // the resources are customresources so, stored in a single file per resource
@@ -291,12 +293,15 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 						sortObjects = append(sortObjects, item)
 					} else {
 						if len(resources) > 0 {
-							_, ok := resources[item.GetName()]
-							if ok {
-								handleObject(item)
+							if _, ok := resources[item.GetName()]; ok {
+								if err := handleObject(item); err != nil {
+									return err
+								}
 							}
 						} else {
-							handleObject(item)
+							if err := handleObject(item); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -305,12 +310,15 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 					sortObjects = sortResources(sortObjects, vars.SortBy)
 					for _, item := range sortObjects {
 						if len(resources) > 0 {
-							_, ok := resources[item.GetName()]
-							if ok {
-								handleObject(item)
+							if _, ok := resources[item.GetName()]; ok {
+								if err := handleObject(item); err != nil {
+									return err
+								}
 							}
 						} else {
-							handleObject(item)
+							if err := handleObject(item); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -334,7 +342,9 @@ func getNamespacesResources(resources map[string]struct{}) error {
 				if vars.SortBy != "" {
 					sortObjects = append(sortObjects, item)
 				} else {
-					handleObject(item)
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -351,7 +361,9 @@ func getNamespacesResources(resources map[string]struct{}) error {
 				if vars.SortBy != "" {
 					sortObjects = append(sortObjects, item)
 				} else {
-					handleObject(item)
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -359,7 +371,9 @@ func getNamespacesResources(resources map[string]struct{}) error {
 	if vars.SortBy != "" {
 		sortObjects = sortResources(sortObjects, vars.SortBy)
 		for _, item := range sortObjects {
-			handleObject(item)
+			if err := handleObject(item); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -392,12 +406,15 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 				UnstructuredItems.Items = append(UnstructuredItems.Items, item)
 			} else {
 				if len(resources) > 0 {
-					_, ok := resources[item.GetName()]
-					if ok {
-						handleObject(item)
+					if _, ok := resources[item.GetName()]; ok {
+						if err := handleObject(item); err != nil {
+							return err
+						}
 					}
 				} else {
-					handleObject(item)
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -405,12 +422,15 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, vars.SortBy)
 			for _, item := range UnstructuredItems.Items {
 				if len(resources) > 0 {
-					_, ok := resources[item.GetName()]
-					if ok {
-						handleObject(item)
+					if _, ok := resources[item.GetName()]; ok {
+						if err := handleObject(item); err != nil {
+							return err
+						}
 					}
 				} else {
-					handleObject(item)
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -423,12 +443,15 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 		}
 		for _, item := range UnstructuredItems.Items {
 			if len(resources) > 0 {
-				_, ok := resources[item.GetName()]
-				if ok {
-					handleObject(item)
+				if _, ok := resources[item.GetName()]; ok {
+					if err := handleObject(item); err != nil {
+						return err
+					}
 				}
 			} else {
-				handleObject(item)
+				if err := handleObject(item); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -521,7 +544,7 @@ func handleObject(obj unstructured.Unstructured) error {
 	return nil
 }
 
-func handleOutput(w io.Writer, errOut io.Writer) {
+func handleOutput(w io.Writer, errOut io.Writer) error {
 	printer := cliprint.NewTablePrinter(cliprint.PrintOptions{NoHeaders: vars.NoHeaders, Wide: vars.Wide, WithNamespace: false, ShowLabels: false})
 	_resources := make([]string, 0, len(vars.GetArgs))
 	var includesClusterScoped bool
@@ -580,9 +603,8 @@ func handleOutput(w io.Writer, errOut io.Writer) {
 		}
 	} else {
 		if vars.LastKind == vars.CurrentKind {
-			err := printer.PrintObj(&vars.Table, &vars.Output)
-			if err != nil {
-				klog.V(1).ErrorS(err, "ERROR")
+			if err := printer.PrintObj(&vars.Table, &vars.Output); err != nil {
+				return fmt.Errorf("error printing table: %w", err)
 			}
 			vars.Table = metav1.Table{}
 		}
@@ -597,6 +619,7 @@ func handleOutput(w io.Writer, errOut io.Writer) {
 			vars.Output.WriteTo(w)
 		}
 	}
+	return nil
 }
 
 func getPodNetworkConnectivityChecksResources(resources map[string]struct{}) error {
@@ -610,7 +633,9 @@ func getPodNetworkConnectivityChecksResources(resources map[string]struct{}) err
 		for _, item := range UnstructuredItems.Items {
 			_, ok := resources[item.GetName()]
 			if ok || len(resources) == 0 {
-				handleObject(item)
+				if err := handleObject(item); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -1,5 +1,6 @@
 /*
 Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -74,40 +75,45 @@ var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
 var yamlData []byte
 
 var GetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:           "get",
+	Short:         "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			cmd.Help()
-			os.Exit(0)
+			return cmd.Help()
 		}
 		if vars.OutputStringVar == "wide" {
 			vars.Wide = true
 		}
-		err := validateArgs(args)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err.Error())
-			os.Exit(1)
+		if err := validateArgs(args); err != nil {
+			return err
 		}
 		for resource := range vars.GetArgs {
 			resourceNamePlural, resourceGroup, _, namespaced, err := KindGroupNamespaced(resource)
 			if err != nil {
 				klog.V(1).ErrorS(err, "ERROR")
-				os.Exit(1)
+				return err
 			}
 			// namespaces and projects resources
 			// are exceptions to must-gather resources structure
-			if resourceNamePlural == "namespaces" || resourceNamePlural == "projects" {
-				getNamespacesResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			} else if resourceNamePlural == "podnetworkconnectivitychecks" {
-				getPodNetworkConnectivityChecksResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			} else if namespaced {
-				getNamespacedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			} else {
-				getClusterScopedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			var rerr error
+			switch {
+			case resourceNamePlural == "namespaces" || resourceNamePlural == "projects":
+				rerr = getNamespacesResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			case resourceNamePlural == "podnetworkconnectivitychecks":
+				rerr = getPodNetworkConnectivityChecksResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			case namespaced:
+				rerr = getNamespacedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			default:
+				rerr = getClusterScopedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			}
+			if rerr != nil {
+				return rerr
 			}
 		}
 		handleOutput(os.Stdout, os.Stderr)
+		return nil
 	},
 }
 
@@ -193,7 +199,7 @@ func init() {
 	templateprinters.AddTemplateOpenShiftHandlers(vars.TableGenerator)
 }
 
-func getNamespacedResources(resourceNamePlural string, resourceGroup string, resources map[string]struct{}) {
+func getNamespacedResources(resourceNamePlural string, resourceGroup string, resources map[string]struct{}) error {
 	var namespaces []string
 	if vars.AllNamespaceBoolVar {
 		vars.Namespace = ""
@@ -227,21 +233,18 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 						podPath := fmt.Sprintf("%s/%s/%s.yaml", podsDir, podName, podName)
 						_file, err := os.ReadFile(podPath)
 						if err != nil {
-							fmt.Fprintf(os.Stderr, "error reading %s: %s\n", podPath, err)
-							os.Exit(1)
+							return fmt.Errorf("error reading %s: %w", podPath, err)
 						}
 						var podItem unstructured.Unstructured
 						if err := yaml.Unmarshal(_file, &podItem); err != nil {
-							fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file "+podPath)
-							os.Exit(1)
+							return fmt.Errorf("error unmarshaling %s: %w", podPath, err)
 						}
 						if podItem.Object != nil {
 							UnstructuredItems.Items = append(UnstructuredItems.Items, podItem)
 						}
 					}
 				} else {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(1)
+					return fmt.Errorf("error unmarshaling %s: %w", resourcesItemsPath, err)
 				}
 			}
 
@@ -277,11 +280,13 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 						continue
 					}
 					resourceYamlPath := resourceDir + "/" + f.Name()
-					_file, _ := os.ReadFile(resourceYamlPath)
+					_file, err := os.ReadFile(resourceYamlPath)
+					if err != nil {
+						return fmt.Errorf("error reading %s: %w", resourceYamlPath, err)
+					}
 					item := unstructured.Unstructured{}
 					if err := yaml.Unmarshal(_file, &item); err != nil {
-						fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
-						os.Exit(1)
+						return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 					}
 					if vars.SortBy != "" {
 						sortObjects = append(sortObjects, item)
@@ -313,9 +318,10 @@ func getNamespacedResources(resourceNamePlural string, resourceGroup string, res
 			}
 		}
 	}
+	return nil
 }
 
-func getNamespacesResources(resources map[string]struct{}) {
+func getNamespacesResources(resources map[string]struct{}) error {
 	var sortObjects []unstructured.Unstructured
 	if len(resources) > 0 {
 		for namespace := range resources {
@@ -324,8 +330,7 @@ func getNamespacesResources(resources map[string]struct{}) {
 			if err == nil {
 				item := unstructured.Unstructured{}
 				if err := yaml.Unmarshal(_file, &item); err != nil {
-					fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
-					os.Exit(1)
+					return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 				}
 				if vars.SortBy != "" {
 					sortObjects = append(sortObjects, item)
@@ -342,8 +347,7 @@ func getNamespacesResources(resources map[string]struct{}) {
 			if err == nil {
 				item := unstructured.Unstructured{}
 				if err := yaml.Unmarshal(_file, &item); err != nil {
-					fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
-					os.Exit(1)
+					return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 				}
 				if vars.SortBy != "" {
 					sortObjects = append(sortObjects, item)
@@ -359,9 +363,10 @@ func getNamespacesResources(resources map[string]struct{}) {
 			handleObject(item)
 		}
 	}
+	return nil
 }
 
-func getClusterScopedResources(resourceNamePlural string, resourceGroup string, resources map[string]struct{}) {
+func getClusterScopedResources(resourceNamePlural string, resourceGroup string, resources map[string]struct{}) error {
 	UnstructuredItems := types.UnstructuredList{ApiVersion: "v1", Kind: "List"}
 	resourcePath := fmt.Sprintf("%s/cluster-scoped-resources/%s/%s.yaml", vars.MustGatherRootPath, resourceGroup, resourceNamePlural)
 	_file, err := os.ReadFile(resourcePath)
@@ -373,15 +378,16 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 		}
 		for _, f := range resourcesFiles {
 			resourceYamlPath := resourceDir + "/" + f.Name()
-			_file, _ := os.ReadFile(resourceYamlPath)
+			_file, err := os.ReadFile(resourceYamlPath)
+			if err != nil {
+				return fmt.Errorf("error reading %s: %w", resourceYamlPath, err)
+			}
 			item := unstructured.Unstructured{}
 			if err := yaml.Unmarshal(_file, &item); err != nil {
-				fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourceYamlPath)
-				os.Exit(1)
+				return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 			}
 			if item.IsList() {
-				fmt.Fprintln(os.Stderr, "error: file \""+resourceYamlPath+"\" contains a \"List\" objectKind, while it should contain a single resource.")
-				os.Exit(1)
+				return fmt.Errorf("file %q contains a \"List\" objectKind, while it should contain a single resource", resourceYamlPath)
 			}
 			if vars.SortBy != "" {
 				UnstructuredItems.Items = append(UnstructuredItems.Items, item)
@@ -411,8 +417,7 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 		}
 	} else {
 		if err := yaml.Unmarshal(_file, &UnstructuredItems); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return fmt.Errorf("error unmarshaling %s: %w", resourcePath, err)
 		}
 		if vars.SortBy != "" {
 			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, vars.SortBy)
@@ -428,7 +433,7 @@ func getClusterScopedResources(resourceNamePlural string, resourceGroup string, 
 			}
 		}
 	}
-
+	return nil
 }
 
 func handleObject(obj unstructured.Unstructured) error {
@@ -595,14 +600,13 @@ func handleOutput(w io.Writer, errOut io.Writer) {
 	}
 }
 
-func getPodNetworkConnectivityChecksResources(resources map[string]struct{}) {
+func getPodNetworkConnectivityChecksResources(resources map[string]struct{}) error {
 	resourcesYamlPath := vars.MustGatherRootPath + "/pod_network_connectivity_check/podnetworkconnectivitychecks.yaml"
 	_file, err := os.ReadFile(resourcesYamlPath)
 	if err == nil {
 		UnstructuredItems := types.UnstructuredList{ApiVersion: "v1", Kind: "List"}
 		if err := yaml.Unmarshal(_file, &UnstructuredItems); err != nil {
-			fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file: "+resourcesYamlPath)
-			os.Exit(1)
+			return fmt.Errorf("error unmarshaling %s: %w", resourcesYamlPath, err)
 		}
 		for _, item := range UnstructuredItems.Items {
 			_, ok := resources[item.GetName()]
@@ -611,6 +615,7 @@ func getPodNetworkConnectivityChecksResources(resources map[string]struct{}) {
 			}
 		}
 	}
+	return nil
 }
 
 func sortResources(list []unstructured.Unstructured, sortBy string) []unstructured.Unstructured {

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -96,19 +96,18 @@ var GetCmd = &cobra.Command{
 			}
 			// namespaces and projects resources
 			// are exceptions to must-gather resources structure
-			var rerr error
 			switch {
 			case resourceNamePlural == "namespaces" || resourceNamePlural == "projects":
-				rerr = getNamespacesResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+				err = getNamespacesResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			case resourceNamePlural == "podnetworkconnectivitychecks":
-				rerr = getPodNetworkConnectivityChecksResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+				err = getPodNetworkConnectivityChecksResources(vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			case namespaced:
-				rerr = getNamespacedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+				err = getNamespacedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			default:
-				rerr = getClusterScopedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+				err = getClusterScopedResources(resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 			}
-			if rerr != nil {
-				return rerr
+			if err != nil {
+				return err
 			}
 		}
 		return handleOutput(os.Stdout, os.Stderr)
@@ -462,7 +461,10 @@ func handleObject(obj unstructured.Unstructured) error {
 	if vars.Namespace != "" && obj.GetNamespace() != "" && vars.Namespace != obj.GetNamespace() {
 		return nil
 	}
-	labelsOk, _ := helpers.MatchLabelsFromMap(obj.GetLabels(), vars.LabelSelectorStringVar)
+	labelsOk, err := helpers.MatchLabelsFromMap(obj.GetLabels(), vars.LabelSelectorStringVar)
+	if err != nil {
+		return fmt.Errorf("invalid label selector %q: %w", vars.LabelSelectorStringVar, err)
+	}
 	if !labelsOk {
 		return nil
 	}
@@ -575,11 +577,18 @@ func handleOutput(w io.Writer, errOut io.Writer) error {
 			}
 		}
 	} else if strings.HasPrefix(vars.OutputStringVar, "jsonpath=") {
-		jsonPathTemplate := helpers.GetJsonTemplate(vars.OutputStringVar)
+		jsonPathTemplate, err := helpers.GetJsonTemplate(vars.OutputStringVar)
+		if err != nil {
+			return err
+		}
 		if vars.SingleResource && len(vars.UnstructuredList.Items) == 1 {
-			helpers.ExecuteJsonPath(vars.UnstructuredList.Items[0].Object, jsonPathTemplate)
+			if err := helpers.ExecuteJsonPath(vars.UnstructuredList.Items[0].Object, jsonPathTemplate); err != nil {
+				return err
+			}
 		} else if !vars.SingleResource && len(vars.UnstructuredList.Items) > 0 {
-			helpers.ExecuteJsonPath(vars.JsonPathList, jsonPathTemplate)
+			if err := helpers.ExecuteJsonPath(vars.JsonPathList, jsonPathTemplate); err != nil {
+				return err
+			}
 		} else {
 			if vars.Namespace != "" {
 				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, vars.Namespace)

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -75,10 +75,9 @@ var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
 var yamlData []byte
 
 var GetCmd = &cobra.Command{
-	Use:           "get",
-	Short:         "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:          "get",
+	Short:        "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return cmd.Help()

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -1,7 +1,11 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 package get
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -67,5 +71,55 @@ func TestHandleEmptyWideOutput(t *testing.T) {
 			}
 			vars.GetArgs = make(map[string]map[string]struct{})
 		})
+	}
+}
+
+func TestGetClusterScopedResources_ReturnsErrorOnCorruptYAML(t *testing.T) {
+	root := t.TempDir()
+	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "clusterversions.yaml"), []byte("{ unterminated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := vars.MustGatherRootPath
+	t.Cleanup(func() { vars.MustGatherRootPath = saved })
+	vars.MustGatherRootPath = root
+
+	if err := getClusterScopedResources("clusterversions", "config.openshift.io", nil); err == nil {
+		t.Fatalf("expected error from corrupt yaml, got nil")
+	}
+}
+
+func TestGetCmd_PropagatesErrorThroughCobra(t *testing.T) {
+	root := t.TempDir()
+	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "clusterversions.yaml"), []byte("{ unterminated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	savedPath := vars.MustGatherRootPath
+	savedArgs := vars.GetArgs
+	t.Cleanup(func() {
+		vars.MustGatherRootPath = savedPath
+		vars.GetArgs = savedArgs
+		GetCmd.SetArgs(nil)
+		GetCmd.SetOut(nil)
+		GetCmd.SetErr(nil)
+	})
+	vars.MustGatherRootPath = root
+	vars.GetArgs = make(map[string]map[string]struct{})
+
+	GetCmd.SetArgs([]string{"clusterversions"})
+	GetCmd.SetOut(new(bytes.Buffer))
+	GetCmd.SetErr(new(bytes.Buffer))
+
+	if err := GetCmd.Execute(); err == nil {
+		t.Fatalf("expected GetCmd.Execute to return an error from the corrupt fixture, got nil")
 	}
 }

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/gmeghnag/omc/types"
 	"github.com/gmeghnag/omc/vars"
 )
@@ -121,5 +123,72 @@ func TestGetCmd_PropagatesErrorThroughCobra(t *testing.T) {
 
 	if err := GetCmd.Execute(); err == nil {
 		t.Fatalf("expected GetCmd.Execute to return an error from the corrupt fixture, got nil")
+	}
+}
+
+func TestHandleObject_ReturnsErrorOnBadCustomColumns(t *testing.T) {
+	savedOutput := vars.OutputStringVar
+	savedNs := vars.Namespace
+	savedSel := vars.LabelSelectorStringVar
+	t.Cleanup(func() {
+		vars.OutputStringVar = savedOutput
+		vars.Namespace = savedNs
+		vars.LabelSelectorStringVar = savedSel
+	})
+	vars.OutputStringVar = "custom-columns=BAD"
+	vars.Namespace = ""
+	vars.LabelSelectorStringVar = ""
+
+	obj := unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("ConfigMap")
+	obj.SetName("test")
+
+	if err := handleObject(obj); err == nil {
+		t.Fatalf("expected handleObject to return error for malformed custom-columns spec, got nil")
+	}
+}
+
+func TestGetCmd_PropagatesHandleObjectError(t *testing.T) {
+	root := t.TempDir()
+	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: config.openshift.io/v1
+  kind: ClusterVersion
+  metadata:
+    name: version
+  status:
+    desired:
+      version: "4.17.11"
+`)
+	if err := os.WriteFile(filepath.Join(rdir, "clusterversions.yaml"), fixture, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	savedPath := vars.MustGatherRootPath
+	savedArgs := vars.GetArgs
+	savedOutput := vars.OutputStringVar
+	t.Cleanup(func() {
+		vars.MustGatherRootPath = savedPath
+		vars.GetArgs = savedArgs
+		vars.OutputStringVar = savedOutput
+		GetCmd.SetArgs(nil)
+		GetCmd.SetOut(nil)
+		GetCmd.SetErr(nil)
+	})
+	vars.MustGatherRootPath = root
+	vars.GetArgs = make(map[string]map[string]struct{})
+
+	GetCmd.SetArgs([]string{"clusterversions", "-o", "custom-columns=BAD"})
+	GetCmd.SetOut(new(bytes.Buffer))
+	GetCmd.SetErr(new(bytes.Buffer))
+
+	if err := GetCmd.Execute(); err == nil {
+		t.Fatalf("expected GetCmd.Execute to surface the CustomColumnsTable error, got nil")
 	}
 }

--- a/cmd/helpers/helpers.go
+++ b/cmd/helpers/helpers.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 package helpers
 
 import (
@@ -102,18 +104,19 @@ func FormatDiffTime(diff time.Duration) string {
 	return strconv.Itoa(int(diff.Seconds())) + "s"
 }
 
-func ExecuteJsonPath(data interface{}, jsonPathTemplate string) {
+func ExecuteJsonPath(data interface{}, jsonPathTemplate string) error {
 	buf := new(bytes.Buffer)
 	jPath := jsonpath.New("out")
 	jPath.AllowMissingKeys(false)
 	jPath.EnableJSONOutput(false)
-	err := jPath.Parse(jsonPathTemplate)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "error: error parsing jsonpath "+jsonPathTemplate+", "+err.Error())
-		os.Exit(1)
+	if err := jPath.Parse(jsonPathTemplate); err != nil {
+		return fmt.Errorf("error parsing jsonpath %s, %w", jsonPathTemplate, err)
 	}
-	jPath.Execute(buf, data)
+	if err := jPath.Execute(buf, data); err != nil {
+		return fmt.Errorf("error executing jsonpath %s, %w", jsonPathTemplate, err)
+	}
 	fmt.Print(buf)
+	return nil
 }
 
 func CreateConfigFile(cfgFilePath string) {
@@ -273,7 +276,9 @@ func PrintOutput(resource interface{}, columns int16, outputFlag string, resourc
 		fmt.Println(string(j))
 	}
 	if strings.HasPrefix(outputFlag, "jsonpath=") {
-		ExecuteJsonPath(resource, jsonPathTemplate)
+		if err := ExecuteJsonPath(resource, jsonPathTemplate); err != nil {
+			fmt.Fprintln(os.Stderr, "error: "+err.Error())
+		}
 	}
 	return false
 }
@@ -303,17 +308,15 @@ func Cat(filePath string) {
 	fmt.Print(string(fileBytes[:]))
 }
 
-func GetJsonTemplate(outputStringVar string) string {
-	jsonPathTemplate := ""
-	if strings.HasPrefix(outputStringVar, "jsonpath=") {
-		s := outputStringVar[9:]
-		if len(s) < 1 {
-			fmt.Fprintln(os.Stderr, "error: template format specified but no template given")
-			os.Exit(1)
-		}
-		jsonPathTemplate = s
+func GetJsonTemplate(outputStringVar string) (string, error) {
+	if !strings.HasPrefix(outputStringVar, "jsonpath=") {
+		return "", nil
 	}
-	return jsonPathTemplate
+	s := outputStringVar[9:]
+	if len(s) < 1 {
+		return "", fmt.Errorf("template format specified but no template given")
+	}
+	return s, nil
 }
 
 func StringInSlice(a string, list []string) bool {

--- a/main.go
+++ b/main.go
@@ -1,5 +1,6 @@
 /*
 Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +21,5 @@ import (
 )
 
 func main() {
-	//fmt.Println("inside main") // FLOW 3
-	root.RootCmd.Execute()
+	root.Execute()
 }

--- a/pkg/tablegenerator/tablegenerator.go
+++ b/pkg/tablegenerator/tablegenerator.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 package tablegenerator
 
 import (
@@ -42,7 +44,11 @@ func CustomColumnsTable(unstruct *unstructured.Unstructured) (*metav1.Table, err
 	}
 	cells := make([]interface{}, 0)
 	for _, column := range table.ColumnDefinitions {
-		matches := format.FindStringSubmatch(fieldSelectors[column.Name])
+		selector := fieldSelectors[column.Name]
+		matches := format.FindStringSubmatch(selector)
+		if matches == nil {
+			return nil, fmt.Errorf("invalid custom-columns selector %q for column %q (expected form: %s:.metadata.name)", selector, column.Name, column.Name)
+		}
 		cells = append(cells, helpers.GetFromJsonPath(unstruct.Object, fmt.Sprintf("%s%s%s", "{.", matches[1], "}")))
 	}
 	table.Rows = []metav1.TableRow{{Cells: cells}}

--- a/root/root.go
+++ b/root/root.go
@@ -1,5 +1,6 @@
 /*
 Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -63,7 +64,9 @@ var RootCmd = &cobra.Command{ // FLOW 4
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the RootCmd.
 func Execute() {
-	cobra.CheckErr(RootCmd.Execute())
+	if err := RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func init() {


### PR DESCRIPTION
Hi @gmeghnag, 3 years late patch for #76 :)

The helpers in `cmd/get` were calling `os.Exit` directly, which made them impossible to unit-test since a corrupt fixture would just kill the test binary. `GetCmd` now uses `RunE` and the helpers return errors, with `main`/`root.Execute` mapping a non-nil error to exit 1 so the exit-code behavior is unchanged.

While I was in there, downstream I noticed a couple of `os.ReadFile` errors that were silently discarded are now returned, and I set `SilenceUsage: true` on `GetCmd` so cobra doesn't dump usage on runtime errors.

I kept the scope to the `get` subcommand since that is what mainly concerns me downstream. Let me know if you'd like the same treatment on other subcommands in a follow-up PR.

There was no CONTRIBUTING file, so I added a one-line copyright on files I touched. Happy to iterate if you'd prefer a different style.