### PR TITLE
cmd/logs: return errors instead of os.Exit

### DIFF
--- a/cmd/logs/helpers.go
+++ b/cmd/logs/helpers.go
@@ -65,7 +65,7 @@ func parseCRILog(log []byte, infoLevel bool, warningLevel bool, errorLevel bool)
 	return "", nil
 }
 
-func FilterCatLogs(filePath string, logLevels []string) {
+func FilterCatLogs(filePath string, logLevels []string) error {
 	var infoLevel, warningLevel, errorLevel bool
 	for _, i := range logLevels {
 		if i == "info" {
@@ -78,14 +78,15 @@ func FilterCatLogs(filePath string, logLevels []string) {
 			errorLevel = true
 		}
 	}
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		fmt.Fprintln(os.Stderr, "error: file "+filePath+" does not exist")
-		os.Exit(1)
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file %s does not exist", filePath)
+		}
+		return fmt.Errorf("stat file %s: %w", filePath, err)
 	}
 	file, err := os.Open(filePath)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "error: can't open file "+filePath)
-		os.Exit(1)
+		return fmt.Errorf("can't open file %s: %w", filePath, err)
 	}
 	defer file.Close()
 
@@ -94,14 +95,17 @@ func FilterCatLogs(filePath string, logLevels []string) {
 	for scanner.Scan() {
 		log, err := parseCRILog(scanner.Bytes(), infoLevel, warningLevel, errorLevel)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return err
 		}
 		if log != "" {
 			fmt.Println(log)
 		}
 
 	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan file %s: %w", filePath, err)
+	}
+	return nil
 }
 
 func isNumber(char byte) bool {

--- a/cmd/logs/logreader.go
+++ b/cmd/logs/logreader.go
@@ -92,25 +92,22 @@ func (l *LogReader) FromRotated() {
 // Print the current reader (filtered) to a provided writer.
 // If unfilter, write to provided writer (w).
 // If filtered read from reader line-by-line and apply the filter.
-func (l *LogReader) Read(w io.Writer) {
+func (l *LogReader) Read(w io.Writer) error {
 	var logs []string
 	for _, filename := range *l.files {
 		reader, err := open(l.dirname + "/" + filename)
 		if err != nil {
-			if !os.IsNotExist(err) {
-				// since we're scanning through logs dynamically don't error out if log files do not exist
-				fmt.Errorf("failed to open log file: %v", err)
+			if os.IsNotExist(err) {
+				// Must-gathers may omit selected current, previous, or rotated logs.
+				continue
 			}
-			continue
+			return fmt.Errorf("failed to open log file %s: %w", filename, err)
 		}
 		defer reader.Close()
-		if err != nil {
-			fmt.Println(err)
-		}
 		if l.filter == nil && l.tail == -1 {
 			// without filter and without tail, copy entire content to the provided writer
 			if _, err := io.Copy(w, reader); err != nil {
-				log.Fatalf("fatal: %v", err)
+				return fmt.Errorf("copy log file %s: %w", filename, err)
 			}
 		} else {
 			// with filter or tail, read line by line
@@ -124,17 +121,25 @@ func (l *LogReader) Read(w io.Writer) {
 							logs = logs[1:]
 						}
 					} else {
-						fmt.Fprintln(w, string(log))
+						if _, err := fmt.Fprintln(w, string(log)); err != nil {
+							return fmt.Errorf("write log line from %s: %w", filename, err)
+						}
 					}
 				}
+			}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("scan log file %s: %w", filename, err)
 			}
 		}
 	}
 	if l.tail != -1 {
 		for _, logLine := range logs {
-			fmt.Fprintln(w, logLine)
+			if _, err := fmt.Fprintln(w, logLine); err != nil {
+				return fmt.Errorf("write tailed log line: %w", err)
+			}
 		}
 	}
+	return nil
 }
 
 func (l *LogReader) applyFilter(raw []byte) []byte {

--- a/cmd/logs/logreader_test.go
+++ b/cmd/logs/logreader_test.go
@@ -151,7 +151,9 @@ func TestRead(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			output := new(bytes.Buffer)
-			tc.logReader.Read(output)
+			if err := tc.logReader.Read(output); err != nil {
+				t.Fatal(err)
+			}
 			if tc.expectedFilteredOutText != "" {
 				if strings.Contains(output.String(), tc.expectedFilteredOutText) {
 					t.Errorf("Found '%v' while expecting to be filtered.\n", tc.expectedFilteredOutText)
@@ -195,7 +197,9 @@ func TestReadWithTail(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			output := new(bytes.Buffer)
-			tc.logReader.Read(output)
+			if err := tc.logReader.Read(output); err != nil {
+				t.Fatal(err)
+			}
 			if !strings.Contains(output.String(), tc.expectedText) {
 				t.Errorf("Got: %v \nWant: %v \n", output.String(), tc.expectedText)
 			}

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -17,8 +17,6 @@ package logs
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 
@@ -32,18 +30,18 @@ var LogLevel string
 
 // logsCmd represents the logs command
 var Logs = &cobra.Command{
-	Use:   "logs",
-	Short: "Print the logs for a container in a pod",
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "logs",
+	Short:        "Print the logs for a container in a pod",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if vars.MustGatherRootPath == "" {
-			fmt.Fprintln(os.Stderr, "There are no must-gather resources defined.")
-			os.Exit(1)
+			return fmt.Errorf("there are no must-gather resources defined")
 		}
 		exist, _ := helpers.Exists(vars.MustGatherRootPath + "/namespaces")
 		if !exist {
-			files, err := ioutil.ReadDir(vars.MustGatherRootPath)
+			files, err := os.ReadDir(vars.MustGatherRootPath)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			var QuayString string
 			for _, f := range files {
@@ -54,8 +52,7 @@ var Logs = &cobra.Command{
 				}
 			}
 			if QuayString == "" {
-				fmt.Fprintln(os.Stderr, "Some error occurred, wrong must-gather file composition")
-				os.Exit(1)
+				return fmt.Errorf("wrong must-gather file composition")
 			}
 		}
 		namespaceFlag, _ := cmd.Flags().GetString("namespace")
@@ -74,49 +71,43 @@ var Logs = &cobra.Command{
 		}
 
 		if len(args) == 0 || len(args) > 2 {
-			fmt.Fprintln(os.Stderr, "error: expected 'logs [-p] (POD | TYPE/NAME) [-c CONTAINER]'.")
-			fmt.Fprintln(os.Stderr, "POD or TYPE/NAME is a required argument for the logs command")
-			fmt.Fprintln(os.Stderr, "See 'omc logs -h' for help and examples")
-			os.Exit(1)
+			return fmt.Errorf("expected 'logs [-p] (POD | TYPE/NAME) [-c CONTAINER]'; POD or TYPE/NAME is a required argument for the logs command")
 		}
 		if len(args) == 1 {
 			if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
 				podName = s[1]
 				if podName == "" {
-					fmt.Fprintln(os.Stderr, "arguments in resource/name form must have a single resource and name")
-					os.Exit(1)
+					return fmt.Errorf("arguments in resource/name form must have a single resource and name")
 				}
-				logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
 			} else {
 				podName = s[0]
-				logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
 			}
 		}
 		if len(args) == 2 {
 			if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
 				if containerName != "" {
-					fmt.Fprintln(os.Stderr, "error: only one of -c or an inline [CONTAINER] arg is allowed")
-					os.Exit(1)
+					return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
 				} else {
 					podName = s[1]
 					if podName == "" {
-						fmt.Fprintln(os.Stderr, "error: arguments in resource/name form must have a single resource and name")
-						os.Exit(1)
+						return fmt.Errorf("arguments in resource/name form must have a single resource and name")
 					}
 					containerName = args[1]
-					logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+					return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
 				}
 			} else {
 				if containerName != "" {
-					fmt.Fprintln(os.Stderr, "error: only one of -c or an inline [CONTAINER] arg is allowed")
-					os.Exit(1)
+					return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
 				} else {
 					podName = args[0]
 					containerName = args[1]
-					logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+					return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
 				}
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/logs/logs_error_test.go
+++ b/cmd/logs/logs_error_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logs
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gmeghnag/omc/vars"
+)
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestLogReaderReadReturnsWriterError(t *testing.T) {
+	logReader := &LogReader{
+		dirname: testdata + "namespaces/test-namespace/pods/test-pod/test-container/test-container/logs/",
+		files:   &[]string{"current.log"},
+		filter:  nil,
+		tail:    -1,
+	}
+
+	err := logReader.Read(failingWriter{})
+	if err == nil {
+		t.Fatalf("expected writer error, got nil")
+	}
+	if !strings.Contains(err.Error(), "write failed") {
+		t.Fatalf("expected write failure in error, got %v", err)
+	}
+}
+
+func TestFilterCatLogsReturnsErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		err := FilterCatLogs(filepath.Join(t.TempDir(), "missing.log"), []string{"info"})
+		if err == nil {
+			t.Fatalf("expected missing file error, got nil")
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Fatalf("expected missing file error, got %v", err)
+		}
+	})
+
+	t.Run("malformed cri log", func(t *testing.T) {
+		logPath := filepath.Join(t.TempDir(), "current.log")
+		if err := os.WriteFile(logPath, []byte("not-a-cri-line\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := FilterCatLogs(logPath, []string{"info"})
+		if err == nil {
+			t.Fatalf("expected malformed log error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timestamp is not found") {
+			t.Fatalf("expected timestamp parse error, got %v", err)
+		}
+	})
+}
+
+func TestLogsPodsReturnsErrors(t *testing.T) {
+	t.Run("missing pod", func(t *testing.T) {
+		root := writePodsListFixture(t, podListYAML("other-pod", "test-container"))
+
+		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		if err == nil {
+			t.Fatalf("expected missing pod error, got nil")
+		}
+		if !strings.Contains(err.Error(), "pods test-pod not found") {
+			t.Fatalf("expected missing pod error, got %v", err)
+		}
+	})
+
+	t.Run("invalid container", func(t *testing.T) {
+		root := writePodsListFixture(t, podListYAML("test-pod", "test-container"))
+
+		err := logsPods(root, "test-namespace", "test-pod", "missing-container", false, false, false, nil, false, -1)
+		if err == nil {
+			t.Fatalf("expected invalid container error, got nil")
+		}
+		if !strings.Contains(err.Error(), "container missing-container is not valid for pod test-pod") {
+			t.Fatalf("expected invalid container error, got %v", err)
+		}
+	})
+
+	t.Run("corrupt pods list", func(t *testing.T) {
+		root := writePodsListFixture(t, "{ unterminated")
+
+		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		if err == nil {
+			t.Fatalf("expected corrupt pods list error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error unmarshaling") {
+			t.Fatalf("expected unmarshal error, got %v", err)
+		}
+	})
+
+	t.Run("corrupt fallback pod", func(t *testing.T) {
+		root := t.TempDir()
+		podDir := filepath.Join(root, "namespaces", "test-namespace", "pods", "test-pod")
+		if err := os.MkdirAll(podDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(podDir, "test-pod.yaml"), []byte("{ unterminated"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		if err == nil {
+			t.Fatalf("expected corrupt fallback pod error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error unmarshaling") {
+			t.Fatalf("expected unmarshal error, got %v", err)
+		}
+	})
+}
+
+func TestLogsCommandReturnsErrors(t *testing.T) {
+	t.Run("invalid argument count", func(t *testing.T) {
+		root := writeLogsRoot(t)
+		restoreLogsCommandState(t)
+		vars.MustGatherRootPath = root
+
+		var stdout, stderr bytes.Buffer
+		Logs.SetOut(&stdout)
+		Logs.SetErr(&stderr)
+		Logs.SetArgs([]string{})
+
+		err := Logs.Execute()
+		if err == nil {
+			t.Fatalf("expected argument error, got nil")
+		}
+		if !strings.Contains(err.Error(), "POD or TYPE/NAME is a required argument") {
+			t.Fatalf("expected argument error, got %v", err)
+		}
+	})
+
+	t.Run("container flag conflicts with inline container", func(t *testing.T) {
+		root := writeLogsRoot(t)
+		restoreLogsCommandState(t)
+		vars.MustGatherRootPath = root
+
+		var stdout, stderr bytes.Buffer
+		Logs.SetOut(&stdout)
+		Logs.SetErr(&stderr)
+		Logs.SetArgs([]string{"-c", "flag-container", "test-pod", "inline-container"})
+
+		err := Logs.Execute()
+		if err == nil {
+			t.Fatalf("expected container conflict error, got nil")
+		}
+		if !strings.Contains(err.Error(), "only one of -c or an inline [CONTAINER] arg is allowed") {
+			t.Fatalf("expected container conflict error, got %v", err)
+		}
+	})
+}
+
+func writeLogsRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "namespaces"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writePodsListFixture(t *testing.T, podsYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	coreDir := filepath.Join(root, "namespaces", "test-namespace", "core")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, "pods.yaml"), []byte(podsYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func podListYAML(podName, containerName string) string {
+	return `apiVersion: v1
+kind: PodList
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: ` + podName + `
+  spec:
+    containers:
+    - name: ` + containerName + `
+`
+}
+
+func restoreLogsCommandState(t *testing.T) {
+	t.Helper()
+	savedPath := vars.MustGatherRootPath
+	savedNamespace := vars.Namespace
+	savedContainer := vars.Container
+	savedPrevious := vars.Previous
+	savedRotated := vars.Rotated
+	savedAllContainers := vars.AllContainers
+	savedInsecureLogs := vars.InsecureLogs
+	savedTail := vars.Tail
+	savedLogLevel := LogLevel
+
+	t.Cleanup(func() {
+		Logs.SetArgs(nil)
+		Logs.SetOut(nil)
+		Logs.SetErr(nil)
+		_ = Logs.PersistentFlags().Set("container", savedContainer)
+		_ = Logs.PersistentFlags().Set("previous", strconv.FormatBool(savedPrevious))
+		_ = Logs.PersistentFlags().Set("rotated", strconv.FormatBool(savedRotated))
+		_ = Logs.PersistentFlags().Set("all-containers", strconv.FormatBool(savedAllContainers))
+		_ = Logs.PersistentFlags().Set("insecure", strconv.FormatBool(savedInsecureLogs))
+		_ = Logs.PersistentFlags().Set("tail", strconv.FormatInt(savedTail, 10))
+		vars.MustGatherRootPath = savedPath
+		vars.Namespace = savedNamespace
+		vars.Container = savedContainer
+		vars.Previous = savedPrevious
+		vars.Rotated = savedRotated
+		vars.AllContainers = savedAllContainers
+		vars.InsecureLogs = savedInsecureLogs
+		vars.Tail = savedTail
+		LogLevel = savedLogLevel
+	})
+}

--- a/cmd/logs/pods.go
+++ b/cmd/logs/pods.go
@@ -17,37 +17,34 @@ package logs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
-func logsPods(currentContextPath string, defaultConfigNamespace string, podName string, containerName string, previousFlag bool, rotatedFlag bool, allContainersFlag bool, logLevels []string, insecureFlag bool, tail int64) {
+func logsPods(currentContextPath string, defaultConfigNamespace string, podName string, containerName string, previousFlag bool, rotatedFlag bool, allContainersFlag bool, logLevels []string, insecureFlag bool, tail int64) error {
 	var logFilter logLineFilter = NewCRILogFilter(logLevels, nil)
 	var _Items v1.PodList
 	CurrentNamespacePath := currentContextPath + "/namespaces/" + defaultConfigNamespace
-	_file, err := ioutil.ReadFile(CurrentNamespacePath + "/core/pods.yaml")
+	podsPath := CurrentNamespacePath + "/core/pods.yaml"
+	_file, err := os.ReadFile(podsPath)
 	if err != nil {
 		// Sometimes the core/pods.yaml might be empty due to unknown reasons when MG is collected
 		// In such cases, we need to look for the pod in the pods directory
-		_file, err = ioutil.ReadFile(CurrentNamespacePath + "/pods/" + podName + "/" + podName + ".yaml")
+		podPath := CurrentNamespacePath + "/pods/" + podName + "/" + podName + ".yaml"
+		_file, err = os.ReadFile(podPath)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error: pod "+podName+" not found.")
-			os.Exit(1)
+			return fmt.Errorf("pod %s not found: %w", podName, err)
 		}
 		// We create a Pod object and append it to the _Items PodList
 		var pod v1.Pod
 		if err := yaml.Unmarshal([]byte(_file), &pod); err != nil {
-			fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file "+CurrentNamespacePath+"/pods/"+podName+"/"+podName+".yaml")
-			os.Exit(1)
+			return fmt.Errorf("error unmarshaling %s: %w", podPath, err)
 		}
 		_Items.Items = append(_Items.Items, pod)
-	}
-	if err := yaml.Unmarshal([]byte(_file), &_Items); err != nil {
-		fmt.Fprintln(os.Stderr, "Error when trying to unmarshal file "+CurrentNamespacePath+"/core/pods.yaml")
-		os.Exit(1)
+	} else if err := yaml.Unmarshal([]byte(_file), &_Items); err != nil {
+		return fmt.Errorf("error unmarshaling %s: %w", podsPath, err)
 	}
 	podMatch := ""
 	for _, Pod := range _Items.Items {
@@ -74,9 +71,11 @@ func logsPods(currentContextPath string, defaultConfigNamespace string, podName 
 					if insecureFlag {
 						log.FromInsecure()
 					}
-					log.Read(os.Stdout)
+					if err := log.Read(os.Stdout); err != nil {
+						return err
+					}
 				}
-				return
+				return nil
 			} else {
 				var containerSlice []v1.Container
 				containerSlice = append(containerSlice, Pod.Spec.Containers...)
@@ -100,11 +99,9 @@ func logsPods(currentContextPath string, defaultConfigNamespace string, podName 
 		}
 		if containerMatch == "" {
 			if containerName != "" {
-				fmt.Fprintln(os.Stderr, "error: container "+containerName+" is not valid for pod "+Pod.Name)
-				os.Exit(1)
+				return fmt.Errorf("container %s is not valid for pod %s", containerName, Pod.Name)
 			} else {
-				fmt.Fprintln(os.Stderr, "error: a container name must be specified for pod "+Pod.Name+", choose one of:", containers)
-				os.Exit(1)
+				return fmt.Errorf("a container name must be specified for pod %s, choose one of: %v", Pod.Name, containers)
 			}
 		} else {
 			log := NewLogReader(CurrentNamespacePath + "/pods/" + Pod.Name + "/" + containerMatch + "/" + containerMatch + "/logs/")
@@ -119,11 +116,13 @@ func logsPods(currentContextPath string, defaultConfigNamespace string, podName 
 			if insecureFlag {
 				log.FromInsecure()
 			}
-			log.Read(os.Stdout)
+			if err := log.Read(os.Stdout); err != nil {
+				return err
+			}
 		}
 	}
 	if podMatch == "" {
-		fmt.Fprintln(os.Stderr, "error: pods "+podName+" not found")
-		os.Exit(1)
+		return fmt.Errorf("pods %s not found", podName)
 	}
+	return nil
 }


### PR DESCRIPTION
Hi @gmeghnag, follow-up to #250 for `cmd/logs`. 

The command and helpers were calling `os.Exit` (and `LogReader.Read` had a `log.Fatalf` for `io.Copy` failures), which made the error paths impossible to unit-test. `Logs` now uses `RunE` and the helpers return errors, with `main` mapping a non-nil error to exit 1 so the exit-code behavior is unchanged.

While I was in there I also fixed:
- a discarded `fmt.Errorf` in `Read` that was swallowing non-`IsNotExist` open errors (permission, etc.)
- same in `FilterCatLogs`
- a missing `scanner.Err()` check at the end of both readers
- and a double-unmarshal in the `logsPods` per-pod fallback path. 

I tried to keep the diff as little as possible (`logs_error_test.go` covers the new branches is the main diff) : I just replace the deprecated `ioutil` with `os` as per go1.16+ standards. Hopefully one subcommand at the time should make review easier.

