### PR TITLE
cmd/get, cmd/logs: take output writers as parameters

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -102,37 +102,41 @@ var GetCmd = &cobra.Command{
 		if len(args) == 0 {
 			return cmd.Help()
 		}
-		if vars.OutputStringVar == "wide" {
-			vars.Wide = true
-		}
-		if err := validateArgs(args); err != nil {
+		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+	},
+}
+
+func Run(stdout, stderr io.Writer, args []string) error {
+	if vars.OutputStringVar == "wide" {
+		vars.Wide = true
+	}
+	if err := validateArgs(args); err != nil {
+		return err
+	}
+	s := newState()
+	for resource := range vars.GetArgs {
+		resourceNamePlural, resourceGroup, _, namespaced, err := KindGroupNamespaced(resource)
+		if err != nil {
+			klog.V(1).ErrorS(err, "ERROR")
 			return err
 		}
-		s := newState()
-		for resource := range vars.GetArgs {
-			resourceNamePlural, resourceGroup, _, namespaced, err := KindGroupNamespaced(resource)
-			if err != nil {
-				klog.V(1).ErrorS(err, "ERROR")
-				return err
-			}
-			// namespaces and projects resources
-			// are exceptions to must-gather resources structure
-			switch {
-			case resourceNamePlural == "namespaces" || resourceNamePlural == "projects":
-				err = getNamespacesResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			case resourceNamePlural == "podnetworkconnectivitychecks":
-				err = getPodNetworkConnectivityChecksResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			case namespaced:
-				err = getNamespacedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			default:
-				err = getClusterScopedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
-			}
-			if err != nil {
-				return err
-			}
+		// namespaces and projects resources
+		// are exceptions to must-gather resources structure
+		switch {
+		case resourceNamePlural == "namespaces" || resourceNamePlural == "projects":
+			err = getNamespacesResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+		case resourceNamePlural == "podnetworkconnectivitychecks":
+			err = getPodNetworkConnectivityChecksResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+		case namespaced:
+			err = getNamespacedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+		default:
+			err = getClusterScopedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
 		}
-		return s.handleOutput(os.Stdout, os.Stderr)
-	},
+		if err != nil {
+			return err
+		}
+	}
+	return s.handleOutput(stdout, stderr)
 }
 
 func init() {
@@ -601,11 +605,11 @@ func (s *state) handleOutput(w io.Writer, errOut io.Writer) error {
 			return err
 		}
 		if vars.SingleResource && len(s.unstructuredList.Items) == 1 {
-			if err := helpers.ExecuteJsonPath(s.unstructuredList.Items[0].Object, jsonPathTemplate); err != nil {
+			if err := helpers.ExecuteJsonPathTo(w, s.unstructuredList.Items[0].Object, jsonPathTemplate); err != nil {
 				return err
 			}
 		} else if !vars.SingleResource && len(s.unstructuredList.Items) > 0 {
-			if err := helpers.ExecuteJsonPath(s.jsonPathList, jsonPathTemplate); err != nil {
+			if err := helpers.ExecuteJsonPathTo(w, s.jsonPathList, jsonPathTemplate); err != nil {
 				return err
 			}
 		} else {

--- a/cmd/helpers/helpers.go
+++ b/cmd/helpers/helpers.go
@@ -105,6 +105,10 @@ func FormatDiffTime(diff time.Duration) string {
 }
 
 func ExecuteJsonPath(data interface{}, jsonPathTemplate string) error {
+	return ExecuteJsonPathTo(os.Stdout, data, jsonPathTemplate)
+}
+
+func ExecuteJsonPathTo(w io.Writer, data interface{}, jsonPathTemplate string) error {
 	buf := new(bytes.Buffer)
 	jPath := jsonpath.New("out")
 	jPath.AllowMissingKeys(false)
@@ -115,7 +119,9 @@ func ExecuteJsonPath(data interface{}, jsonPathTemplate string) error {
 	if err := jPath.Execute(buf, data); err != nil {
 		return fmt.Errorf("error executing jsonpath %s, %w", jsonPathTemplate, err)
 	}
-	fmt.Print(buf)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("error writing jsonpath output: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -17,6 +17,7 @@ package logs
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -34,81 +35,85 @@ var Logs = &cobra.Command{
 	Short:        "Print the logs for a container in a pod",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if vars.MustGatherRootPath == "" {
-			return fmt.Errorf("there are no must-gather resources defined")
-		}
-		exist, _ := helpers.Exists(vars.MustGatherRootPath + "/namespaces")
-		if !exist {
-			files, err := os.ReadDir(vars.MustGatherRootPath)
-			if err != nil {
-				return err
-			}
-			var QuayString string
-			for _, f := range files {
-				if strings.HasPrefix(f.Name(), "quay") {
-					QuayString = f.Name()
-					vars.MustGatherRootPath = vars.MustGatherRootPath + "/" + QuayString
-					break
-				}
-			}
-			if QuayString == "" {
-				return fmt.Errorf("wrong must-gather file composition")
-			}
-		}
 		namespaceFlag, _ := cmd.Flags().GetString("namespace")
 		if namespaceFlag != "" {
 			vars.Namespace = namespaceFlag
 		}
-		podName := ""
-		containerName, _ := cmd.Flags().GetString("container")
-		previousFlag, _ := cmd.Flags().GetBool("previous")
-		rotatedFlag, _ := cmd.Flags().GetBool("rotated")
-		insecureFlag, _ := cmd.Flags().GetBool("insecure")
-		allContainersFlag, _ := cmd.Flags().GetBool("all-containers")
-		logLevels := []string{}
-		if LogLevel != "" {
-			logLevels = strings.Split(LogLevel, ",")
-		}
+		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+	},
+}
 
-		if len(args) == 0 || len(args) > 2 {
-			return fmt.Errorf("expected 'logs [-p] (POD | TYPE/NAME) [-c CONTAINER]'; POD or TYPE/NAME is a required argument for the logs command")
+func Run(stdout, stderr io.Writer, args []string) error {
+	if vars.MustGatherRootPath == "" {
+		return fmt.Errorf("there are no must-gather resources defined")
+	}
+	exist, _ := helpers.Exists(vars.MustGatherRootPath + "/namespaces")
+	if !exist {
+		files, err := os.ReadDir(vars.MustGatherRootPath)
+		if err != nil {
+			return err
 		}
-		if len(args) == 1 {
-			if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
+		var QuayString string
+		for _, f := range files {
+			if strings.HasPrefix(f.Name(), "quay") {
+				QuayString = f.Name()
+				vars.MustGatherRootPath = vars.MustGatherRootPath + "/" + QuayString
+				break
+			}
+		}
+		if QuayString == "" {
+			return fmt.Errorf("wrong must-gather file composition")
+		}
+	}
+	podName := ""
+	containerName := vars.Container
+	previousFlag := vars.Previous
+	rotatedFlag := vars.Rotated
+	insecureFlag := vars.InsecureLogs
+	allContainersFlag := vars.AllContainers
+	logLevels := []string{}
+	if LogLevel != "" {
+		logLevels = strings.Split(LogLevel, ",")
+	}
+
+	if len(args) == 0 || len(args) > 2 {
+		return fmt.Errorf("expected 'logs [-p] (POD | TYPE/NAME) [-c CONTAINER]'; POD or TYPE/NAME is a required argument for the logs command")
+	}
+	if len(args) == 1 {
+		if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
+			podName = s[1]
+			if podName == "" {
+				return fmt.Errorf("arguments in resource/name form must have a single resource and name")
+			}
+			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+		} else {
+			podName = s[0]
+			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+		}
+	}
+	if len(args) == 2 {
+		if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
+			if containerName != "" {
+				return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
+			} else {
 				podName = s[1]
 				if podName == "" {
 					return fmt.Errorf("arguments in resource/name form must have a single resource and name")
 				}
-				return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				containerName = args[1]
+				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+			}
+		} else {
+			if containerName != "" {
+				return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
 			} else {
-				podName = s[0]
-				return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				podName = args[0]
+				containerName = args[1]
+				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
 			}
 		}
-		if len(args) == 2 {
-			if s := strings.Split(args[0], "/"); len(s) == 2 && (s[0] == "po" || s[0] == "pod" || s[0] == "pods") {
-				if containerName != "" {
-					return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
-				} else {
-					podName = s[1]
-					if podName == "" {
-						return fmt.Errorf("arguments in resource/name form must have a single resource and name")
-					}
-					containerName = args[1]
-					return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
-				}
-			} else {
-				if containerName != "" {
-					return fmt.Errorf("only one of -c or an inline [CONTAINER] arg is allowed")
-				} else {
-					podName = args[0]
-					containerName = args[1]
-					return logsPods(vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
-				}
-			}
-		}
-		return nil
-	},
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/logs/logs_error_test.go
+++ b/cmd/logs/logs_error_test.go
@@ -18,6 +18,7 @@ package logs
 import (
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -81,7 +82,7 @@ func TestLogsPodsReturnsErrors(t *testing.T) {
 	t.Run("missing pod", func(t *testing.T) {
 		root := writePodsListFixture(t, podListYAML("other-pod", "test-container"))
 
-		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		err := logsPods(io.Discard, root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
 		if err == nil {
 			t.Fatalf("expected missing pod error, got nil")
 		}
@@ -93,7 +94,7 @@ func TestLogsPodsReturnsErrors(t *testing.T) {
 	t.Run("invalid container", func(t *testing.T) {
 		root := writePodsListFixture(t, podListYAML("test-pod", "test-container"))
 
-		err := logsPods(root, "test-namespace", "test-pod", "missing-container", false, false, false, nil, false, -1)
+		err := logsPods(io.Discard, root, "test-namespace", "test-pod", "missing-container", false, false, false, nil, false, -1)
 		if err == nil {
 			t.Fatalf("expected invalid container error, got nil")
 		}
@@ -105,7 +106,7 @@ func TestLogsPodsReturnsErrors(t *testing.T) {
 	t.Run("corrupt pods list", func(t *testing.T) {
 		root := writePodsListFixture(t, "{ unterminated")
 
-		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		err := logsPods(io.Discard, root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
 		if err == nil {
 			t.Fatalf("expected corrupt pods list error, got nil")
 		}
@@ -124,7 +125,7 @@ func TestLogsPodsReturnsErrors(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err := logsPods(root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
+		err := logsPods(io.Discard, root, "test-namespace", "test-pod", "", false, false, false, nil, false, -1)
 		if err == nil {
 			t.Fatalf("expected corrupt fallback pod error, got nil")
 		}

--- a/cmd/logs/pods.go
+++ b/cmd/logs/pods.go
@@ -17,13 +17,14 @@ package logs
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
-func logsPods(currentContextPath string, defaultConfigNamespace string, podName string, containerName string, previousFlag bool, rotatedFlag bool, allContainersFlag bool, logLevels []string, insecureFlag bool, tail int64) error {
+func logsPods(stdout io.Writer, currentContextPath string, defaultConfigNamespace string, podName string, containerName string, previousFlag bool, rotatedFlag bool, allContainersFlag bool, logLevels []string, insecureFlag bool, tail int64) error {
 	var logFilter logLineFilter = NewCRILogFilter(logLevels, nil)
 	var _Items v1.PodList
 	CurrentNamespacePath := currentContextPath + "/namespaces/" + defaultConfigNamespace
@@ -71,7 +72,7 @@ func logsPods(currentContextPath string, defaultConfigNamespace string, podName 
 					if insecureFlag {
 						log.FromInsecure()
 					}
-					if err := log.Read(os.Stdout); err != nil {
+					if err := log.Read(stdout); err != nil {
 						return err
 					}
 				}
@@ -116,7 +117,7 @@ func logsPods(currentContextPath string, defaultConfigNamespace string, podName 
 			if insecureFlag {
 				log.FromInsecure()
 			}
-			if err := log.Read(os.Stdout); err != nil {
+			if err := log.Read(stdout); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Hi @gmeghnag,

`GetCmd` and `Logs` write to `os.Stdout`/`os.Stderr` directly, so library callers have to swap process-wide stdout to capture the output.

With this MR both subcommands now expose `func Run(stdout, stderr io.Writer, args []string) error` for callers to choose where output goes. However cobra `RunE` is reduced to a thin wrapper forwarding `cmd.OutOrStdout()` / `cmd.ErrOrStderr()` to keep omc's CLI behavior unchanged.

`cmd/helpers` exposes `ExecuteJsonPathTo(w io.Writer, ...)` for the same reason. I kept `ExecuteJsonPath` as a one-liner around it for backward compatibility with external importers. I can drop it in the next round of MR instead if you prefer.