### PR TITLE
Fix crash while reading ~/.omc/customresourcedefinitions

### DIFF
--- a/cmd/get/helpers.go
+++ b/cmd/get/helpers.go
@@ -201,6 +201,9 @@ func kindGroupNamespacedFromCrds(alias string) (string, string, string, bool, er
 			fmt.Fprintln(os.Stderr, rErr)
 		}
 		for _, f := range crds {
+			if f.IsDir() {
+				continue
+			}
 			crdYamlPath := omcCrdsPath + f.Name()
 			crdByte, _ := ioutil.ReadFile(crdYamlPath)
 			_crd := &apiextensionsv1.CustomResourceDefinition{}


### PR DESCRIPTION
If the directory in $SUBJECT contains another subdir, this will be read and cause a segfault because a read from a dir returns NULL:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x150 pc=0x288268a]

goroutine 1 [running]:
github.com/gmeghnag/omc/cmd/get.kindGroupNamespacedFromCrds({0x7ffc5ce643b0, 0x3})
        /home/runner/work/omc/omc/cmd/get/helpers.go:229 +0x104a
github.com/gmeghnag/omc/cmd/get.KindGroupNamespaced({0x7ffc5ce643b0, 0x3})
        /home/runner/work/omc/omc/cmd/get/helpers.go:144 +0x945
github.com/gmeghnag/omc/cmd/get.validateArgs({0xc000b03280?, 0x0?, 0x0?})
        /home/runner/work/omc/omc/cmd/get/helpers.go:46 +0x2db
github.com/gmeghnag/omc/cmd/get.init.func1(0xc000832200?, {0xc000b03280?, 0x4?, 0x3468b97?})
        /home/runner/work/omc/omc/cmd/get/get.go:87 +0x94
github.com/spf13/cobra.(*Command).execute(0x5a8bc80, {0xc000b03240, 0x1, 0x1})
        /home/runner/work/omc/omc/vendor/github.com/spf13/cobra/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x5a88020)
        /home/runner/work/omc/omc/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/work/omc/omc/vendor/github.com/spf13/cobra/command.go:1041
main.main()
        /home/runner/work/omc/omc/main.go:24 +0x1a

Fixed by simply checking if the entry is a dir and in this case, continue with the next.