### PR TITLE
Refactor/get logs options

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -74,11 +74,20 @@ var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
 //go:embed known-resources.yaml
 var yamlData []byte
 
+// Flag binding targets. Cobra binds flags to variable addresses, so these
+// stay as package vars. RunE copies them into an Options for Run.
+var (
+	labelSelectorFlag string
+	noHeadersFlag     bool
+	sortByFlag        string
+)
+
 // state holds the per-invocation accumulator fields that handleObject and
 // handleOutput build up as resources are read. Keeping these out of the vars
 // package makes the get pipeline reentrant and is a precondition for any
 // future concurrent producer/consumer in this command.
 type state struct {
+	opts             *Options
 	output           bytes.Buffer
 	table            metav1.Table
 	currentKind      string
@@ -87,8 +96,9 @@ type state struct {
 	jsonPathList     types.JsonPathList
 }
 
-func newState() *state {
+func newState(opts *Options) *state {
 	return &state{
+		opts:             opts,
 		unstructuredList: types.UnstructuredList{Kind: "List", ApiVersion: "v1", Items: []unstructured.Unstructured{}},
 		jsonPathList:     types.JsonPathList{Kind: "List", ApiVersion: "v1"},
 	}
@@ -102,19 +112,39 @@ var GetCmd = &cobra.Command{
 		if len(args) == 0 {
 			return cmd.Help()
 		}
-		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+		opts := Options{
+			Namespace:     vars.Namespace,
+			Output:        vars.OutputStringVar,
+			LabelSelector: labelSelectorFlag,
+			NoHeaders:     noHeadersFlag,
+			AllNamespaces: vars.AllNamespaceBoolVar,
+			ShowLabels:    vars.ShowLabelsBoolVar,
+			SortBy:        sortByFlag,
+			GetArgs:       make(map[string]map[string]struct{}),
+		}
+		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args)
 	},
 }
 
-func Run(stdout, stderr io.Writer, args []string) error {
-	if vars.OutputStringVar == "wide" {
-		vars.Wide = true
+func Run(stdout, stderr io.Writer, opts Options, args []string) error {
+	if opts.GetArgs == nil {
+		opts.GetArgs = make(map[string]map[string]struct{})
 	}
-	if err := validateArgs(args); err != nil {
+	if opts.Output == "wide" {
+		opts.Wide = true
+	}
+	if err := validateArgs(&opts, args); err != nil {
 		return err
 	}
-	s := newState()
-	for resource := range vars.GetArgs {
+	// tablegenerator still reads these from vars; bridge until that package
+	// is converted to take options too.
+	vars.Wide = opts.Wide
+	vars.ShowKind = opts.ShowKind
+	vars.OutputStringVar = opts.Output
+	vars.Namespace = opts.Namespace
+	vars.ShowLabelsBoolVar = opts.ShowLabels
+	s := newState(&opts)
+	for resource := range opts.GetArgs {
 		resourceNamePlural, resourceGroup, _, namespaced, err := KindGroupNamespaced(resource)
 		if err != nil {
 			klog.V(1).ErrorS(err, "ERROR")
@@ -124,13 +154,13 @@ func Run(stdout, stderr io.Writer, args []string) error {
 		// are exceptions to must-gather resources structure
 		switch {
 		case resourceNamePlural == "namespaces" || resourceNamePlural == "projects":
-			err = getNamespacesResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			err = getNamespacesResources(s, opts.GetArgs[resourceNamePlural+"."+resourceGroup])
 		case resourceNamePlural == "podnetworkconnectivitychecks":
-			err = getPodNetworkConnectivityChecksResources(s, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			err = getPodNetworkConnectivityChecksResources(s, opts.GetArgs[resourceNamePlural+"."+resourceGroup])
 		case namespaced:
-			err = getNamespacedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			err = getNamespacedResources(s, resourceNamePlural, resourceGroup, opts.GetArgs[resourceNamePlural+"."+resourceGroup])
 		default:
-			err = getClusterScopedResources(s, resourceNamePlural, resourceGroup, vars.GetArgs[resourceNamePlural+"."+resourceGroup])
+			err = getClusterScopedResources(s, resourceNamePlural, resourceGroup, opts.GetArgs[resourceNamePlural+"."+resourceGroup])
 		}
 		if err != nil {
 			return err
@@ -141,16 +171,15 @@ func Run(stdout, stderr io.Writer, args []string) error {
 
 func init() {
 	GetCmd.PersistentFlags().BoolVarP(&vars.AllNamespaceBoolVar, "all-namespaces", "A", false, "If present, list the requested object(s) across all namespaces.")
-	GetCmd.PersistentFlags().BoolVar(&vars.NoHeaders, "no-headers", false, "When using the default or custom-column output format, don't print headers (default print headers).")
+	GetCmd.PersistentFlags().BoolVar(&noHeadersFlag, "no-headers", false, "When using the default or custom-column output format, don't print headers (default print headers).")
 	GetCmd.PersistentFlags().BoolVar(&vars.ShowManagedFields, "show-managed-fields", false, "If true, show the managedFields when printing objects in JSON or YAML format.")
 	GetCmd.PersistentFlags().BoolVarP(&vars.ShowLabelsBoolVar, "show-labels", "", false, "When printing, show all labels as the last column (default hide labels column)")
 	GetCmd.PersistentFlags().StringVarP(&vars.OutputStringVar, "output", "o", "", "Output format. One of: json|yaml|wide|jsonpath|custom-columns=...")
-	GetCmd.PersistentFlags().StringVarP(&vars.LabelSelectorStringVar, "selector", "l", "", "selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
-	GetCmd.PersistentFlags().StringVarP(&vars.SortBy, "sort-by", "", "", "If non-empty, sort list types using this field specification. The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}').")
+	GetCmd.PersistentFlags().StringVarP(&labelSelectorFlag, "selector", "l", "", "selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	GetCmd.PersistentFlags().StringVarP(&sortByFlag, "sort-by", "", "", "If non-empty, sort list types using this field specification. The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}').")
 }
 
 func init() {
-	vars.GetArgs = make(map[string]map[string]struct{})
 	vars.AliasToCrd = make(map[string]apiextensionsv1.CustomResourceDefinition)
 	vars.ArgPresent = make(map[string]bool)
 	vars.KnownResources = make(map[string]map[string]interface{})
@@ -221,15 +250,16 @@ func init() {
 
 func getNamespacedResources(s *state, resourceNamePlural string, resourceGroup string, resources map[string]struct{}) error {
 	var namespaces []string
-	if vars.AllNamespaceBoolVar {
-		vars.Namespace = ""
+	if s.opts.AllNamespaces {
+		s.opts.Namespace = ""
+		s.opts.ShowNamespace = true
 		vars.ShowNamespace = true
 		_namespaces, _ := ReadDirForResources(vars.MustGatherRootPath + "/namespaces/")
 		for _, f := range _namespaces {
 			namespaces = append(namespaces, f.Name())
 		}
 	} else {
-		namespaces = append(namespaces, vars.Namespace)
+		namespaces = append(namespaces, s.opts.Namespace)
 	}
 	for _, namespace := range namespaces {
 		UnstructuredItems := types.UnstructuredList{ApiVersion: "v1", Kind: "List"}
@@ -268,8 +298,8 @@ func getNamespacedResources(s *state, resourceNamePlural string, resourceGroup s
 				}
 			}
 
-			if vars.SortBy != "" {
-				UnstructuredItems.Items = sortResources(UnstructuredItems.Items, vars.SortBy)
+			if s.opts.SortBy != "" {
+				UnstructuredItems.Items = sortResources(UnstructuredItems.Items, s.opts.SortBy)
 			}
 			for _, item := range UnstructuredItems.Items {
 				if len(resources) > 0 {
@@ -311,7 +341,7 @@ func getNamespacedResources(s *state, resourceNamePlural string, resourceGroup s
 					if err := yaml.Unmarshal(_file, &item); err != nil {
 						return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 					}
-					if vars.SortBy != "" {
+					if s.opts.SortBy != "" {
 						sortObjects = append(sortObjects, item)
 					} else {
 						if len(resources) > 0 {
@@ -328,8 +358,8 @@ func getNamespacedResources(s *state, resourceNamePlural string, resourceGroup s
 					}
 				}
 
-				if vars.SortBy != "" {
-					sortObjects = sortResources(sortObjects, vars.SortBy)
+				if s.opts.SortBy != "" {
+					sortObjects = sortResources(sortObjects, s.opts.SortBy)
 					for _, item := range sortObjects {
 						if len(resources) > 0 {
 							if _, ok := resources[item.GetName()]; ok {
@@ -361,7 +391,7 @@ func getNamespacesResources(s *state, resources map[string]struct{}) error {
 				if err := yaml.Unmarshal(_file, &item); err != nil {
 					return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 				}
-				if vars.SortBy != "" {
+				if s.opts.SortBy != "" {
 					sortObjects = append(sortObjects, item)
 				} else {
 					if err := s.handleObject(item); err != nil {
@@ -380,7 +410,7 @@ func getNamespacesResources(s *state, resources map[string]struct{}) error {
 				if err := yaml.Unmarshal(_file, &item); err != nil {
 					return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 				}
-				if vars.SortBy != "" {
+				if s.opts.SortBy != "" {
 					sortObjects = append(sortObjects, item)
 				} else {
 					if err := s.handleObject(item); err != nil {
@@ -390,8 +420,8 @@ func getNamespacesResources(s *state, resources map[string]struct{}) error {
 			}
 		}
 	}
-	if vars.SortBy != "" {
-		sortObjects = sortResources(sortObjects, vars.SortBy)
+	if s.opts.SortBy != "" {
+		sortObjects = sortResources(sortObjects, s.opts.SortBy)
 		for _, item := range sortObjects {
 			if err := s.handleObject(item); err != nil {
 				return err
@@ -424,7 +454,7 @@ func getClusterScopedResources(s *state, resourceNamePlural string, resourceGrou
 			if item.IsList() {
 				return fmt.Errorf("file %q contains a \"List\" objectKind, while it should contain a single resource", resourceYamlPath)
 			}
-			if vars.SortBy != "" {
+			if s.opts.SortBy != "" {
 				UnstructuredItems.Items = append(UnstructuredItems.Items, item)
 			} else {
 				if len(resources) > 0 {
@@ -440,8 +470,8 @@ func getClusterScopedResources(s *state, resourceNamePlural string, resourceGrou
 				}
 			}
 		}
-		if vars.SortBy != "" {
-			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, vars.SortBy)
+		if s.opts.SortBy != "" {
+			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, s.opts.SortBy)
 			for _, item := range UnstructuredItems.Items {
 				if len(resources) > 0 {
 					if _, ok := resources[item.GetName()]; ok {
@@ -460,8 +490,8 @@ func getClusterScopedResources(s *state, resourceNamePlural string, resourceGrou
 		if err := yaml.Unmarshal(_file, &UnstructuredItems); err != nil {
 			return fmt.Errorf("error unmarshaling %s: %w", resourcePath, err)
 		}
-		if vars.SortBy != "" {
-			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, vars.SortBy)
+		if s.opts.SortBy != "" {
+			UnstructuredItems.Items = sortResources(UnstructuredItems.Items, s.opts.SortBy)
 		}
 		for _, item := range UnstructuredItems.Items {
 			if len(resources) > 0 {
@@ -481,25 +511,25 @@ func getClusterScopedResources(s *state, resourceNamePlural string, resourceGrou
 }
 
 func (s *state) handleObject(obj unstructured.Unstructured) error {
-	if vars.Namespace != "" && obj.GetNamespace() != "" && vars.Namespace != obj.GetNamespace() {
+	if s.opts.Namespace != "" && obj.GetNamespace() != "" && s.opts.Namespace != obj.GetNamespace() {
 		return nil
 	}
-	labelsOk, err := helpers.MatchLabelsFromMap(obj.GetLabels(), vars.LabelSelectorStringVar)
+	labelsOk, err := helpers.MatchLabelsFromMap(obj.GetLabels(), s.opts.LabelSelector)
 	if err != nil {
-		return fmt.Errorf("invalid label selector %q: %w", vars.LabelSelectorStringVar, err)
+		return fmt.Errorf("invalid label selector %q: %w", s.opts.LabelSelector, err)
 	}
 	if !labelsOk {
 		return nil
 	}
 	s.lastKind = obj.GetKind()
-	if vars.OutputStringVar == "yaml" || vars.OutputStringVar == "json" {
+	if s.opts.Output == "yaml" || s.opts.Output == "json" {
 		if !vars.ShowManagedFields {
 			obj.SetManagedFields(nil)
 		}
 		s.unstructuredList.Items = append(s.unstructuredList.Items, obj)
 		return nil
 	}
-	if strings.HasPrefix(vars.OutputStringVar, "jsonpath=") {
+	if strings.HasPrefix(s.opts.Output, "jsonpath=") {
 		if !vars.ShowManagedFields {
 			obj.SetManagedFields(nil)
 		}
@@ -507,7 +537,7 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 		s.jsonPathList.Items = append(s.jsonPathList.Items, obj.Object)
 		return nil
 	}
-	if vars.OutputStringVar == "name" {
+	if s.opts.Output == "name" {
 		if obj.GetAPIVersion() == "v1" {
 			s.output.WriteString(strings.ToLower(obj.GetKind()) + "/" + obj.GetName() + "\n")
 		} else {
@@ -522,7 +552,7 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 	}
 	klog.V(3).Info("INFO deserializing ", obj.GetKind(), " ", obj.GetName())
 	var objectTable *metav1.Table
-	if strings.HasPrefix(vars.OutputStringVar, "custom-columns=") {
+	if strings.HasPrefix(s.opts.Output, "custom-columns=") {
 		objectTable, err = tablegenerator.CustomColumnsTable(&obj)
 		if err != nil {
 			klog.V(1).ErrorS(err, err.Error())
@@ -554,7 +584,7 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 		s.table.Rows = append(s.table.Rows, objectTable.Rows...)
 	} else {
 		// printo la tabella dell'oggetto precedente
-		printer := cliprint.NewTablePrinter(cliprint.PrintOptions{NoHeaders: vars.NoHeaders, Wide: vars.Wide, WithNamespace: false, ShowLabels: false})
+		printer := cliprint.NewTablePrinter(cliprint.PrintOptions{NoHeaders: s.opts.NoHeaders, Wide: s.opts.Wide, WithNamespace: false, ShowLabels: false})
 		err = printer.PrintObj(&s.table, &s.output)
 		if err != nil {
 			klog.V(1).ErrorS(err, err.Error())
@@ -570,10 +600,10 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 }
 
 func (s *state) handleOutput(w io.Writer, errOut io.Writer) error {
-	printer := cliprint.NewTablePrinter(cliprint.PrintOptions{NoHeaders: vars.NoHeaders, Wide: vars.Wide, WithNamespace: false, ShowLabels: false})
-	_resources := make([]string, 0, len(vars.GetArgs))
+	printer := cliprint.NewTablePrinter(cliprint.PrintOptions{NoHeaders: s.opts.NoHeaders, Wide: s.opts.Wide, WithNamespace: false, ShowLabels: false})
+	_resources := make([]string, 0, len(s.opts.GetArgs))
 	var includesClusterScoped bool
-	for resource := range vars.GetArgs {
+	for resource := range s.opts.GetArgs {
 		_resources = append(_resources, resource)
 		// if at least one resource is cluster-scoped, never include a namespace in the output if no resources are found of the kind
 		_, _, _, namespaced, _ := KindGroupNamespaced(resource)
@@ -583,52 +613,52 @@ func (s *state) handleOutput(w io.Writer, errOut io.Writer) error {
 	}
 	sort.Strings(_resources)
 	resources := strings.Join(_resources, ",")
-	if vars.OutputStringVar == "json" {
-		if vars.SingleResource && len(s.unstructuredList.Items) == 1 {
+	if s.opts.Output == "json" {
+		if s.opts.SingleResource && len(s.unstructuredList.Items) == 1 {
 			data, _ := json.MarshalIndent(s.unstructuredList.Items[0].Object, "", "  ")
 			data = append(data, '\n')
 			fmt.Fprintf(w, "%s", data)
-		} else if !vars.SingleResource && len(s.unstructuredList.Items) > 0 {
+		} else if !s.opts.SingleResource && len(s.unstructuredList.Items) > 0 {
 			data, _ := json.MarshalIndent(s.unstructuredList, "", "  ")
 			data = append(data, '\n')
 			fmt.Fprintf(w, "%s", data)
 		} else {
-			if vars.Namespace != "" {
-				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, vars.Namespace)
+			if s.opts.Namespace != "" {
+				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, s.opts.Namespace)
 			} else {
 				fmt.Fprintf(errOut, "No resources %s found.\n", resources)
 			}
 		}
-	} else if strings.HasPrefix(vars.OutputStringVar, "jsonpath=") {
-		jsonPathTemplate, err := helpers.GetJsonTemplate(vars.OutputStringVar)
+	} else if strings.HasPrefix(s.opts.Output, "jsonpath=") {
+		jsonPathTemplate, err := helpers.GetJsonTemplate(s.opts.Output)
 		if err != nil {
 			return err
 		}
-		if vars.SingleResource && len(s.unstructuredList.Items) == 1 {
+		if s.opts.SingleResource && len(s.unstructuredList.Items) == 1 {
 			if err := helpers.ExecuteJsonPathTo(w, s.unstructuredList.Items[0].Object, jsonPathTemplate); err != nil {
 				return err
 			}
-		} else if !vars.SingleResource && len(s.unstructuredList.Items) > 0 {
+		} else if !s.opts.SingleResource && len(s.unstructuredList.Items) > 0 {
 			if err := helpers.ExecuteJsonPathTo(w, s.jsonPathList, jsonPathTemplate); err != nil {
 				return err
 			}
 		} else {
-			if vars.Namespace != "" {
-				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, vars.Namespace)
+			if s.opts.Namespace != "" {
+				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, s.opts.Namespace)
 			} else {
 				fmt.Fprintf(errOut, "No resources %s found.\n", resources)
 			}
 		}
-	} else if vars.OutputStringVar == "yaml" {
-		if vars.SingleResource && len(s.unstructuredList.Items) == 1 {
+	} else if s.opts.Output == "yaml" {
+		if s.opts.SingleResource && len(s.unstructuredList.Items) == 1 {
 			data, _ := yaml.Marshal(s.unstructuredList.Items[0].Object)
 			fmt.Fprintf(w, "%s", data)
 		} else if len(s.unstructuredList.Items) > 0 {
 			data, _ := yaml.Marshal(s.unstructuredList)
 			fmt.Fprintf(w, "%s", data)
 		} else {
-			if vars.Namespace != "" {
-				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, vars.Namespace)
+			if s.opts.Namespace != "" {
+				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, s.opts.Namespace)
 			} else {
 				fmt.Fprintf(errOut, "No resources %s found.\n", resources)
 			}
@@ -642,10 +672,10 @@ func (s *state) handleOutput(w io.Writer, errOut io.Writer) error {
 		}
 		if s.output.Len() == 0 {
 			// never print the (default/current) namespace if at least one cluster-scoped resource is requested
-			if vars.Namespace == "" || includesClusterScoped {
+			if s.opts.Namespace == "" || includesClusterScoped {
 				fmt.Fprintf(errOut, "No resources %s found.\n", resources)
 			} else {
-				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, vars.Namespace)
+				fmt.Fprintf(errOut, "No resources %s found in %s namespace.\n", resources, s.opts.Namespace)
 			}
 		} else {
 			s.output.WriteTo(w)
@@ -711,12 +741,12 @@ func sortResources(list []unstructured.Unstructured, sortBy string) []unstructur
 
 		err := jpath.Execute(abuf, a.UnstructuredContent())
 		if err != nil {
-			klog.V(3).ErrorS(fmt.Errorf("field %s not found in object %s/%s", vars.SortBy, b.GetKind(), b.GetName()), "jsonpath error")
+			klog.V(3).ErrorS(fmt.Errorf("field %s not found in object %s/%s", sortBy, b.GetKind(), b.GetName()), "jsonpath error")
 			return 0
 		}
 		err = jpath.Execute(bbuf, b.UnstructuredContent())
 		if err != nil {
-			klog.V(3).ErrorS(fmt.Errorf("field %s not found in object %s/%s", vars.SortBy, b.GetKind(), b.GetName()), "jsonpath error")
+			klog.V(3).ErrorS(fmt.Errorf("field %s not found in object %s/%s", sortBy, b.GetKind(), b.GetName()), "jsonpath error")
 			return 0
 		}
 

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -64,14 +64,14 @@ func TestHandleEmptyWideOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			vars.MustGatherRootPath = "../../testdata/"
-			vars.Namespace = tt.namespace
-			validateArgs(tt.rtype)
-			newState().handleOutput(&stdout, &stderr)
+			opts := newOptions()
+			opts.Namespace = tt.namespace
+			validateArgs(&opts, tt.rtype)
+			newState(&opts).handleOutput(&stdout, &stderr)
 			if !strings.Contains(stderr.String(), tt.want) {
 				t.Errorf("Got: %v \n", stderr.String())
 				t.Errorf("Want: %v \n", tt.want)
 			}
-			vars.GetArgs = make(map[string]map[string]struct{})
 		})
 	}
 }
@@ -90,7 +90,8 @@ func TestGetClusterScopedResources_ReturnsErrorOnCorruptYAML(t *testing.T) {
 	t.Cleanup(func() { vars.MustGatherRootPath = saved })
 	vars.MustGatherRootPath = root
 
-	if err := getClusterScopedResources(newState(), "clusterversions", "config.openshift.io", nil); err == nil {
+	opts := newOptions()
+	if err := getClusterScopedResources(newState(&opts), "clusterversions", "config.openshift.io", nil); err == nil {
 		t.Fatalf("expected error from corrupt yaml, got nil")
 	}
 }
@@ -106,16 +107,13 @@ func TestGetCmd_PropagatesErrorThroughCobra(t *testing.T) {
 	}
 
 	savedPath := vars.MustGatherRootPath
-	savedArgs := vars.GetArgs
 	t.Cleanup(func() {
 		vars.MustGatherRootPath = savedPath
-		vars.GetArgs = savedArgs
 		GetCmd.SetArgs(nil)
 		GetCmd.SetOut(nil)
 		GetCmd.SetErr(nil)
 	})
 	vars.MustGatherRootPath = root
-	vars.GetArgs = make(map[string]map[string]struct{})
 
 	GetCmd.SetArgs([]string{"clusterversions"})
 	GetCmd.SetOut(new(bytes.Buffer))
@@ -128,23 +126,20 @@ func TestGetCmd_PropagatesErrorThroughCobra(t *testing.T) {
 
 func TestHandleObject_ReturnsErrorOnBadCustomColumns(t *testing.T) {
 	savedOutput := vars.OutputStringVar
-	savedNs := vars.Namespace
-	savedSel := vars.LabelSelectorStringVar
-	t.Cleanup(func() {
-		vars.OutputStringVar = savedOutput
-		vars.Namespace = savedNs
-		vars.LabelSelectorStringVar = savedSel
-	})
+	t.Cleanup(func() { vars.OutputStringVar = savedOutput })
+	// tablegenerator still reads vars.OutputStringVar, so bridge it for this
+	// unit test that bypasses Run.
 	vars.OutputStringVar = "custom-columns=BAD"
-	vars.Namespace = ""
-	vars.LabelSelectorStringVar = ""
+
+	opts := newOptions()
+	opts.Output = "custom-columns=BAD"
 
 	obj := unstructured.Unstructured{}
 	obj.SetAPIVersion("v1")
 	obj.SetKind("ConfigMap")
 	obj.SetName("test")
 
-	if err := newState().handleObject(obj); err == nil {
+	if err := newState(&opts).handleObject(obj); err == nil {
 		t.Fatalf("expected handleObject to return error for malformed custom-columns spec, got nil")
 	}
 }
@@ -171,24 +166,17 @@ items:
 	}
 
 	savedPath := vars.MustGatherRootPath
-	savedArgs := vars.GetArgs
-	savedOutput := vars.OutputStringVar
-	savedNs := vars.Namespace
 	t.Cleanup(func() {
 		vars.MustGatherRootPath = savedPath
-		vars.GetArgs = savedArgs
-		vars.OutputStringVar = savedOutput
-		vars.Namespace = savedNs
 	})
 	vars.MustGatherRootPath = root
-	vars.GetArgs = map[string]map[string]struct{}{
-		"clusterversions.config.openshift.io": {},
-	}
-	vars.OutputStringVar = ""
-	vars.Namespace = ""
 
 	run := func() string {
-		s := newState()
+		opts := newOptions()
+		opts.GetArgs = map[string]map[string]struct{}{
+			"clusterversions.config.openshift.io": {},
+		}
+		s := newState(&opts)
 		if err := getClusterScopedResources(s, "clusterversions", "config.openshift.io", nil); err != nil {
 			t.Fatalf("getClusterScopedResources: %v", err)
 		}
@@ -231,18 +219,15 @@ items:
 	}
 
 	savedPath := vars.MustGatherRootPath
-	savedArgs := vars.GetArgs
 	savedOutput := vars.OutputStringVar
 	t.Cleanup(func() {
 		vars.MustGatherRootPath = savedPath
-		vars.GetArgs = savedArgs
 		vars.OutputStringVar = savedOutput
 		GetCmd.SetArgs(nil)
 		GetCmd.SetOut(nil)
 		GetCmd.SetErr(nil)
 	})
 	vars.MustGatherRootPath = root
-	vars.GetArgs = make(map[string]map[string]struct{})
 
 	GetCmd.SetArgs([]string{"clusterversions", "-o", "custom-columns=BAD"})
 	GetCmd.SetOut(new(bytes.Buffer))
@@ -250,5 +235,73 @@ items:
 
 	if err := GetCmd.Execute(); err == nil {
 		t.Fatalf("expected GetCmd.Execute to surface the CustomColumnsTable error, got nil")
+	}
+}
+
+// TestRun_LibraryAndCobraParity checks that calling Run directly with an
+// Options produces the same result as GetCmd.Execute() with the equivalent
+// flags.
+func TestRun_LibraryAndCobraParity(t *testing.T) {
+	root := t.TempDir()
+	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: config.openshift.io/v1
+  kind: ClusterVersion
+  metadata:
+    name: version
+  status:
+    desired:
+      version: "4.17.11"
+`)
+	if err := os.WriteFile(filepath.Join(rdir, "clusterversions.yaml"), fixture, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	savedPath := vars.MustGatherRootPath
+	savedOutput := vars.OutputStringVar
+	savedNs := vars.Namespace
+	savedWide := vars.Wide
+	savedShowKind := vars.ShowKind
+	savedShowNs := vars.ShowNamespace
+	savedShowLabels := vars.ShowLabelsBoolVar
+	t.Cleanup(func() {
+		vars.MustGatherRootPath = savedPath
+		vars.OutputStringVar = savedOutput
+		vars.Namespace = savedNs
+		vars.Wide = savedWide
+		vars.ShowKind = savedShowKind
+		vars.ShowNamespace = savedShowNs
+		vars.ShowLabelsBoolVar = savedShowLabels
+		GetCmd.SetArgs(nil)
+		GetCmd.SetOut(nil)
+		GetCmd.SetErr(nil)
+	})
+	vars.MustGatherRootPath = root
+
+	var libOut, libErr bytes.Buffer
+	opts := newOptions()
+	opts.Output = "yaml"
+	if err := Run(&libOut, &libErr, opts, []string{"clusterversions"}); err != nil {
+		t.Fatalf("library Run: %v", err)
+	}
+
+	var cobraOut, cobraErr bytes.Buffer
+	GetCmd.SetArgs([]string{"clusterversions", "-o", "yaml"})
+	GetCmd.SetOut(&cobraOut)
+	GetCmd.SetErr(&cobraErr)
+	if err := GetCmd.Execute(); err != nil {
+		t.Fatalf("GetCmd.Execute: %v", err)
+	}
+
+	if libOut.String() != cobraOut.String() {
+		t.Fatalf("stdout drift between library and cobra paths\nlibrary:\n%s\ncobra:\n%s", libOut.String(), cobraOut.String())
+	}
+	if libOut.Len() == 0 {
+		t.Fatalf("expected non-empty output from fixture")
 	}
 }

--- a/cmd/get/helpers.go
+++ b/cmd/get/helpers.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func validateArgs(args []string) error {
+func validateArgs(opts *Options, args []string) error {
 	if len(args) == 1 && args[0] == "all" {
 		args = []string{"pods.core,services.core,daemonsets.apps,deployments.apps,replicasets.apps,statefulsets.apps,replicationcontrollers.core,deploymentconfigs.apps.openshift.io,builds.build.openshift.io,buildconfigs.build.openshift.io,jobs.batch,cronjobs.batch,routes.route.openshift.io,ingresses.networking.k8s.io,"}
 	}
@@ -26,15 +26,15 @@ func validateArgs(args []string) error {
 	args = _args
 	if len(args) == 1 && !strings.Contains(args[0], "/") {
 		if strings.Contains(args[0], ",") {
-			vars.ShowKind = true
+			opts.ShowKind = true
 			resourcesTypes := strings.Split(strings.TrimPrefix(strings.TrimSuffix(args[0], ","), ","), ",")
 			for _, resourceType := range resourcesTypes {
 				resourceNamePlural, resourceGroup, _, _, err := KindGroupNamespaced(resourceType)
 				if err == nil {
 					if !strings.Contains(resourceType, ".") {
-						vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
+						opts.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
 					} else {
-						vars.GetArgs[resourceType] = make(map[string]struct{})
+						opts.GetArgs[resourceType] = make(map[string]struct{})
 					}
 				} else {
 					return fmt.Errorf("resource type \"%s\" not known.", resourceType)
@@ -46,9 +46,9 @@ func validateArgs(args []string) error {
 			resourceNamePlural, resourceGroup, _, _, err := KindGroupNamespaced(resourceType)
 			if err == nil {
 				if !strings.Contains(resourceType, ".") {
-					vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
+					opts.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
 				} else {
-					vars.GetArgs[resourceType] = make(map[string]struct{})
+					opts.GetArgs[resourceType] = make(map[string]struct{})
 				}
 			} else {
 				return fmt.Errorf("resource type \"%s\" not known.", resourceType)
@@ -56,7 +56,7 @@ func validateArgs(args []string) error {
 		}
 	} else if len(args) > 0 && strings.Contains(args[0], "/") {
 		if len(args) == 1 {
-			vars.SingleResource = true
+			opts.SingleResource = true
 		}
 		for _, arg := range args {
 			if strings.Contains(arg, "/") {
@@ -64,12 +64,12 @@ func validateArgs(args []string) error {
 				resourceType, resourceName := resource[0], resource[1]
 				resourceNamePlural, resourceGroup, _, _, err := KindGroupNamespaced(resourceType)
 				if err == nil {
-					_, ok := vars.GetArgs[resourceNamePlural+"."+resourceGroup]
+					_, ok := opts.GetArgs[resourceNamePlural+"."+resourceGroup]
 					if !ok {
-						vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
-						vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
+						opts.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
+						opts.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 					} else {
-						vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
+						opts.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 					}
 				} else {
 					return fmt.Errorf("resource type \"%s\" not known.", resourceType)
@@ -78,25 +78,25 @@ func validateArgs(args []string) error {
 				return fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'omc get resource/<resource_name>' instead of 'omc get resource resource/<resource_name>'")
 			}
 		}
-		if len(vars.GetArgs) > 1 {
-			vars.ShowKind = true
+		if len(opts.GetArgs) > 1 {
+			opts.ShowKind = true
 		}
 	} else if len(args) > 1 && !strings.Contains(args[0], "/") {
 		resourceType := args[0]
 		resourceNamePlural, resourceGroup, _, _, err := KindGroupNamespaced(resourceType)
 		if err == nil {
-			vars.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
+			opts.GetArgs[resourceNamePlural+"."+resourceGroup] = make(map[string]struct{})
 		} else {
 			return fmt.Errorf("resource type \"%s\" not known.", resourceType)
 		}
 		if len(args[0:]) == 2 {
-			vars.SingleResource = true
+			opts.SingleResource = true
 		}
 		for _, resourceName := range args[1:] {
 			if strings.Contains(resourceName, "/") {
 				return fmt.Errorf("there is no need to specify a resource type as a separate argument when passing arguments in resource/name form (e.g. 'omc get resource/<resource_name>' instead of 'omc get resource resource/<resource_name>'")
 			}
-			vars.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
+			opts.GetArgs[resourceNamePlural+"."+resourceGroup][resourceName] = struct{}{}
 		}
 	}
 	return nil

--- a/cmd/get/options.go
+++ b/cmd/get/options.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package get
+
+// Options holds the configuration for a single get invocation. Fields are
+// populated from the cobra-bound flags before Run is invoked.
+type Options struct {
+	Namespace      string
+	Output         string
+	LabelSelector  string
+	NoHeaders      bool
+	AllNamespaces  bool
+	ShowLabels     bool
+	Wide           bool
+	ShowKind       bool
+	ShowNamespace  bool
+	SortBy         string
+	SingleResource bool
+	GetArgs        map[string]map[string]struct{}
+}
+
+func newOptions() Options {
+	return Options{
+		GetArgs: make(map[string]map[string]struct{}),
+	}
+}

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -29,6 +29,17 @@ import (
 
 var LogLevel string
 
+// Flag binding targets. Cobra binds flags to variable addresses, so these
+// stay as package vars. RunE copies them into an Options for Run.
+var (
+	containerFlag     string
+	previousFlag      bool
+	rotatedFlag       bool
+	allContainersFlag bool
+	insecureFlag      bool
+	tailFlag          int64
+)
+
 // logsCmd represents the logs command
 var Logs = &cobra.Command{
 	Use:          "logs",
@@ -39,11 +50,19 @@ var Logs = &cobra.Command{
 		if namespaceFlag != "" {
 			vars.Namespace = namespaceFlag
 		}
-		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), args)
+		opts := Options{
+			Container:     containerFlag,
+			Previous:      previousFlag,
+			Rotated:       rotatedFlag,
+			AllContainers: allContainersFlag,
+			Insecure:      insecureFlag,
+			Tail:          tailFlag,
+		}
+		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args)
 	},
 }
 
-func Run(stdout, stderr io.Writer, args []string) error {
+func Run(stdout, stderr io.Writer, opts Options, args []string) error {
 	if vars.MustGatherRootPath == "" {
 		return fmt.Errorf("there are no must-gather resources defined")
 	}
@@ -66,11 +85,7 @@ func Run(stdout, stderr io.Writer, args []string) error {
 		}
 	}
 	podName := ""
-	containerName := vars.Container
-	previousFlag := vars.Previous
-	rotatedFlag := vars.Rotated
-	insecureFlag := vars.InsecureLogs
-	allContainersFlag := vars.AllContainers
+	containerName := opts.Container
 	logLevels := []string{}
 	if LogLevel != "" {
 		logLevels = strings.Split(LogLevel, ",")
@@ -85,10 +100,10 @@ func Run(stdout, stderr io.Writer, args []string) error {
 			if podName == "" {
 				return fmt.Errorf("arguments in resource/name form must have a single resource and name")
 			}
-			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, opts.Previous, opts.Rotated, opts.AllContainers, logLevels, opts.Insecure, opts.Tail)
 		} else {
 			podName = s[0]
-			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+			return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, opts.Previous, opts.Rotated, opts.AllContainers, logLevels, opts.Insecure, opts.Tail)
 		}
 	}
 	if len(args) == 2 {
@@ -101,7 +116,7 @@ func Run(stdout, stderr io.Writer, args []string) error {
 					return fmt.Errorf("arguments in resource/name form must have a single resource and name")
 				}
 				containerName = args[1]
-				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, opts.Previous, opts.Rotated, opts.AllContainers, logLevels, opts.Insecure, opts.Tail)
 			}
 		} else {
 			if containerName != "" {
@@ -109,7 +124,7 @@ func Run(stdout, stderr io.Writer, args []string) error {
 			} else {
 				podName = args[0]
 				containerName = args[1]
-				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, previousFlag, rotatedFlag, allContainersFlag, logLevels, insecureFlag, vars.Tail)
+				return logsPods(stdout, vars.MustGatherRootPath, vars.Namespace, podName, containerName, opts.Previous, opts.Rotated, opts.AllContainers, logLevels, opts.Insecure, opts.Tail)
 			}
 		}
 	}
@@ -117,11 +132,11 @@ func Run(stdout, stderr io.Writer, args []string) error {
 }
 
 func init() {
-	Logs.PersistentFlags().StringVarP(&vars.Container, "container", "c", "", "Print the logs of this container")
-	Logs.PersistentFlags().BoolVar(&vars.InsecureLogs, "insecure", false, "")
-	Logs.PersistentFlags().BoolVarP(&vars.Previous, "previous", "p", false, "Print the logs for the previous instance of the container in a pod if it exists.")
-	Logs.PersistentFlags().BoolVarP(&vars.Rotated, "rotated", "r", false, "Print the logs for the rotated instance of the container in a pod if it exists.")
-	Logs.PersistentFlags().BoolVarP(&vars.AllContainers, "all-containers", "", false, "Get all containers' logs in the pod(s).")
-	Logs.PersistentFlags().Int64Var(&vars.Tail, "tail", -1, "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines.")
+	Logs.PersistentFlags().StringVarP(&containerFlag, "container", "c", "", "Print the logs of this container")
+	Logs.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "")
+	Logs.PersistentFlags().BoolVarP(&previousFlag, "previous", "p", false, "Print the logs for the previous instance of the container in a pod if it exists.")
+	Logs.PersistentFlags().BoolVarP(&rotatedFlag, "rotated", "r", false, "Print the logs for the rotated instance of the container in a pod if it exists.")
+	Logs.PersistentFlags().BoolVarP(&allContainersFlag, "all-containers", "", false, "Get all containers' logs in the pod(s).")
+	Logs.PersistentFlags().Int64Var(&tailFlag, "tail", -1, "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines.")
 	Logs.Flags().StringVarP(&LogLevel, "log-level", "l", "", "Filter logs by level (info|error|worning), you can filter for more concatenating them comma separated.")
 }

--- a/cmd/logs/logs_error_test.go
+++ b/cmd/logs/logs_error_test.go
@@ -211,16 +211,55 @@ items:
 `
 }
 
+// TestRun_LibraryAndCobraParity checks that calling Run directly with an
+// Options produces the same result as Logs.Execute() with the equivalent
+// flags.
+func TestRun_LibraryAndCobraParity(t *testing.T) {
+	root := writePodsListFixture(t, podListYAML("test-pod", "test-container"))
+	logDir := filepath.Join(root, "namespaces", "test-namespace", "pods", "test-pod", "test-container", "test-container", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logDir, "current.log"), []byte("hello world\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreLogsCommandState(t)
+	vars.MustGatherRootPath = root
+	vars.Namespace = "test-namespace"
+
+	var libOut, libErr bytes.Buffer
+	opts := Options{Container: "test-container", Tail: -1}
+	if err := Run(&libOut, &libErr, opts, []string{"test-pod"}); err != nil {
+		t.Fatalf("library Run: %v", err)
+	}
+
+	var cobraOut, cobraErr bytes.Buffer
+	Logs.SetOut(&cobraOut)
+	Logs.SetErr(&cobraErr)
+	Logs.SetArgs([]string{"-c", "test-container", "test-pod"})
+	if err := Logs.Execute(); err != nil {
+		t.Fatalf("Logs.Execute: %v", err)
+	}
+
+	if libOut.String() != cobraOut.String() {
+		t.Fatalf("stdout drift between library and cobra paths\nlibrary:\n%s\ncobra:\n%s", libOut.String(), cobraOut.String())
+	}
+	if libOut.Len() == 0 {
+		t.Fatalf("expected non-empty output from fixture")
+	}
+}
+
 func restoreLogsCommandState(t *testing.T) {
 	t.Helper()
 	savedPath := vars.MustGatherRootPath
 	savedNamespace := vars.Namespace
-	savedContainer := vars.Container
-	savedPrevious := vars.Previous
-	savedRotated := vars.Rotated
-	savedAllContainers := vars.AllContainers
-	savedInsecureLogs := vars.InsecureLogs
-	savedTail := vars.Tail
+	savedContainer := containerFlag
+	savedPrevious := previousFlag
+	savedRotated := rotatedFlag
+	savedAllContainers := allContainersFlag
+	savedInsecureLogs := insecureFlag
+	savedTail := tailFlag
 	savedLogLevel := LogLevel
 
 	t.Cleanup(func() {
@@ -235,12 +274,6 @@ func restoreLogsCommandState(t *testing.T) {
 		_ = Logs.PersistentFlags().Set("tail", strconv.FormatInt(savedTail, 10))
 		vars.MustGatherRootPath = savedPath
 		vars.Namespace = savedNamespace
-		vars.Container = savedContainer
-		vars.Previous = savedPrevious
-		vars.Rotated = savedRotated
-		vars.AllContainers = savedAllContainers
-		vars.InsecureLogs = savedInsecureLogs
-		vars.Tail = savedTail
 		LogLevel = savedLogLevel
 	})
 }

--- a/cmd/logs/options.go
+++ b/cmd/logs/options.go
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logs
+
+// Options holds the configuration for a single logs invocation. Fields are
+// populated from the cobra-bound flags before Run is invoked.
+type Options struct {
+	Container     string
+	Previous      bool
+	Rotated       bool
+	AllContainers bool
+	Insecure      bool
+	Tail          int64
+}

--- a/vars/vars.go
+++ b/vars/vars.go
@@ -6,12 +6,10 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
-var Tail int64
-var CfgFile, Namespace, MustGatherRootPath, OutputStringVar, LabelSelectorStringVar, Id, Container, OMCVersionHash, OMCVersionTag, DiffCmd, DefaultProject, ForResource string
-var AllNamespaceBoolVar, ShowLabelsBoolVar, Previous, Rotated, AllContainers, UseLocalCRDs, SingleResource, Wide, ShowKind, ShowNamespace, ShowManagedFields, NoHeaders, InsecureLogs bool
+var CfgFile, Namespace, MustGatherRootPath, OutputStringVar, Id, Container, OMCVersionHash, OMCVersionTag, DiffCmd, DefaultProject, ForResource string
+var AllNamespaceBoolVar, ShowLabelsBoolVar, UseLocalCRDs, Wide, ShowKind, ShowNamespace, ShowManagedFields bool
 
 var EventTypes []string
-var GetArgs map[string]map[string]struct{}
 var AliasToCrd map[string]apiextensionsv1.CustomResourceDefinition
 var ArgPresent map[string]bool
 var KnownResources map[string]map[string]interface{}
@@ -19,5 +17,3 @@ var TableGenerator *printers.HumanReadableGenerator
 var CRD *apiextensionsv1.CustomResourceDefinition
 
 var Schema *runtime.Scheme
-
-var SortBy string


### PR DESCRIPTION
Hi @gmeghnag , five more patches, and I'll stop bothering you for a while :)

This one moves most of the per-invocation flags in `cmd/get` and `cmd/logs` out of the package `vars` globals and into an `Options` struct passed in through `Run`. Following patches will complete the refactoring.