### PR TITLE
Refactor/get tablegen and list resource

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -77,9 +77,11 @@ var yamlData []byte
 // Flag binding targets. Cobra binds flags to variable addresses, so these
 // stay as package vars. RunE copies them into an Options for Run.
 var (
-	labelSelectorFlag string
-	noHeadersFlag     bool
-	sortByFlag        string
+	labelSelectorFlag     string
+	noHeadersFlag         bool
+	sortByFlag            string
+	showLabelsFlag        bool
+	showManagedFieldsFlag bool
 )
 
 // state holds the per-invocation accumulator fields that handleObject and
@@ -104,6 +106,19 @@ func newState(opts *Options) *state {
 	}
 }
 
+func (s *state) displayConfig() tablegenerator.DisplayConfig {
+	return tablegenerator.DisplayConfig{
+		Wide:           s.opts.Wide,
+		ShowKind:       s.opts.ShowKind,
+		ShowNamespace:  s.opts.ShowNamespace,
+		ShowLabels:     s.opts.ShowLabels,
+		Namespace:      s.opts.Namespace,
+		Output:         s.opts.Output,
+		TableGenerator: vars.TableGenerator,
+		AliasToCrd:     vars.AliasToCrd,
+	}
+}
+
 var GetCmd = &cobra.Command{
 	Use:          "get",
 	Short:        "Get kubernetes/openshift object in tabular format or wide|yaml|json|jsonpath|custom-columns.",
@@ -113,14 +128,15 @@ var GetCmd = &cobra.Command{
 			return cmd.Help()
 		}
 		opts := Options{
-			Namespace:     vars.Namespace,
-			Output:        vars.OutputStringVar,
-			LabelSelector: labelSelectorFlag,
-			NoHeaders:     noHeadersFlag,
-			AllNamespaces: vars.AllNamespaceBoolVar,
-			ShowLabels:    vars.ShowLabelsBoolVar,
-			SortBy:        sortByFlag,
-			GetArgs:       make(map[string]map[string]struct{}),
+			Namespace:         vars.Namespace,
+			Output:            vars.OutputStringVar,
+			LabelSelector:     labelSelectorFlag,
+			NoHeaders:         noHeadersFlag,
+			AllNamespaces:     vars.AllNamespaceBoolVar,
+			ShowLabels:        showLabelsFlag,
+			ShowManagedFields: showManagedFieldsFlag,
+			SortBy:            sortByFlag,
+			GetArgs:           make(map[string]map[string]struct{}),
 		}
 		return Run(cmd.OutOrStdout(), cmd.ErrOrStderr(), opts, args)
 	},
@@ -136,13 +152,6 @@ func Run(stdout, stderr io.Writer, opts Options, args []string) error {
 	if err := validateArgs(&opts, args); err != nil {
 		return err
 	}
-	// tablegenerator still reads these from vars; bridge until that package
-	// is converted to take options too.
-	vars.Wide = opts.Wide
-	vars.ShowKind = opts.ShowKind
-	vars.OutputStringVar = opts.Output
-	vars.Namespace = opts.Namespace
-	vars.ShowLabelsBoolVar = opts.ShowLabels
 	s := newState(&opts)
 	for resource := range opts.GetArgs {
 		resourceNamePlural, resourceGroup, _, namespaced, err := KindGroupNamespaced(resource)
@@ -172,8 +181,8 @@ func Run(stdout, stderr io.Writer, opts Options, args []string) error {
 func init() {
 	GetCmd.PersistentFlags().BoolVarP(&vars.AllNamespaceBoolVar, "all-namespaces", "A", false, "If present, list the requested object(s) across all namespaces.")
 	GetCmd.PersistentFlags().BoolVar(&noHeadersFlag, "no-headers", false, "When using the default or custom-column output format, don't print headers (default print headers).")
-	GetCmd.PersistentFlags().BoolVar(&vars.ShowManagedFields, "show-managed-fields", false, "If true, show the managedFields when printing objects in JSON or YAML format.")
-	GetCmd.PersistentFlags().BoolVarP(&vars.ShowLabelsBoolVar, "show-labels", "", false, "When printing, show all labels as the last column (default hide labels column)")
+	GetCmd.PersistentFlags().BoolVar(&showManagedFieldsFlag, "show-managed-fields", false, "If true, show the managedFields when printing objects in JSON or YAML format.")
+	GetCmd.PersistentFlags().BoolVarP(&showLabelsFlag, "show-labels", "", false, "When printing, show all labels as the last column (default hide labels column)")
 	GetCmd.PersistentFlags().StringVarP(&vars.OutputStringVar, "output", "o", "", "Output format. One of: json|yaml|wide|jsonpath|custom-columns=...")
 	GetCmd.PersistentFlags().StringVarP(&labelSelectorFlag, "selector", "l", "", "selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	GetCmd.PersistentFlags().StringVarP(&sortByFlag, "sort-by", "", "", "If non-empty, sort list types using this field specification. The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}').")
@@ -253,7 +262,6 @@ func getNamespacedResources(s *state, resourceNamePlural string, resourceGroup s
 	if s.opts.AllNamespaces {
 		s.opts.Namespace = ""
 		s.opts.ShowNamespace = true
-		vars.ShowNamespace = true
 		_namespaces, _ := ReadDirForResources(vars.MustGatherRootPath + "/namespaces/")
 		for _, f := range _namespaces {
 			namespaces = append(namespaces, f.Name())
@@ -523,14 +531,14 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 	}
 	s.lastKind = obj.GetKind()
 	if s.opts.Output == "yaml" || s.opts.Output == "json" {
-		if !vars.ShowManagedFields {
+		if !s.opts.ShowManagedFields {
 			obj.SetManagedFields(nil)
 		}
 		s.unstructuredList.Items = append(s.unstructuredList.Items, obj)
 		return nil
 	}
 	if strings.HasPrefix(s.opts.Output, "jsonpath=") {
-		if !vars.ShowManagedFields {
+		if !s.opts.ShowManagedFields {
 			obj.SetManagedFields(nil)
 		}
 		s.unstructuredList.Items = append(s.unstructuredList.Items, obj)
@@ -552,8 +560,9 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 	}
 	klog.V(3).Info("INFO deserializing ", obj.GetKind(), " ", obj.GetName())
 	var objectTable *metav1.Table
+	cfg := s.displayConfig()
 	if strings.HasPrefix(s.opts.Output, "custom-columns=") {
-		objectTable, err = tablegenerator.CustomColumnsTable(&obj)
+		objectTable, err = tablegenerator.CustomColumnsTable(&obj, cfg)
 		if err != nil {
 			klog.V(1).ErrorS(err, err.Error())
 			return err
@@ -565,14 +574,14 @@ func (s *state) handleObject(obj unstructured.Unstructured) error {
 			if err := yaml.Unmarshal(rawObject, runtimeObjectType); err != nil {
 				klog.V(3).Info(err, err.Error())
 			}
-			objectTable, err = tablegenerator.InternalResourceTable(runtimeObjectType, &obj)
+			objectTable, err = tablegenerator.InternalResourceTable(runtimeObjectType, &obj, cfg)
 			if err != nil {
 				klog.V(3).Info("INFO ", fmt.Sprintf("%s: %s, %s", err.Error(), obj.GetKind(), obj.GetAPIVersion()))
 				klog.V(1).ErrorS(err, err.Error())
 				return err
 			}
 		} else {
-			objectTable, err = tablegenerator.GenerateCustomResourceTable(obj)
+			objectTable, err = tablegenerator.GenerateCustomResourceTable(obj, cfg)
 			if err != nil {
 				klog.V(1).ErrorS(err, err.Error())
 				return err

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -460,7 +460,28 @@ func getClusterScopedResources(s *state, resourceNamePlural string, resourceGrou
 				return fmt.Errorf("error unmarshaling %s: %w", resourceYamlPath, err)
 			}
 			if item.IsList() {
-				return fmt.Errorf("file %q contains a \"List\" objectKind, while it should contain a single resource", resourceYamlPath)
+				var listItems types.UnstructuredList
+				if err := yaml.Unmarshal(_file, &listItems); err != nil {
+					return fmt.Errorf("error unmarshaling list in %s: %w", resourceYamlPath, err)
+				}
+				for _, listItem := range listItems.Items {
+					if s.opts.SortBy != "" {
+						UnstructuredItems.Items = append(UnstructuredItems.Items, listItem)
+					} else {
+						if len(resources) > 0 {
+							if _, ok := resources[listItem.GetName()]; ok {
+								if err := s.handleObject(listItem); err != nil {
+									return err
+								}
+							}
+						} else {
+							if err := s.handleObject(listItem); err != nil {
+								return err
+							}
+						}
+					}
+				}
+				continue
 			}
 			if s.opts.SortBy != "" {
 				UnstructuredItems.Items = append(UnstructuredItems.Items, item)

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -97,6 +97,47 @@ func TestGetClusterScopedResources_ReturnsErrorOnCorruptYAML(t *testing.T) {
 	}
 }
 
+func TestGetClusterScopedResources_AcceptsListInPerResourceDir(t *testing.T) {
+	root := t.TempDir()
+	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io", "clusterversions")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: config.openshift.io/v1
+  kind: ClusterVersion
+  metadata:
+    name: version-a
+- apiVersion: config.openshift.io/v1
+  kind: ClusterVersion
+  metadata:
+    name: version-b
+`)
+	if err := os.WriteFile(filepath.Join(rdir, "clusterversions.yaml"), fixture, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := vars.MustGatherRootPath
+	t.Cleanup(func() { vars.MustGatherRootPath = saved })
+	vars.MustGatherRootPath = root
+
+	opts := newOptions()
+	s := newState(&opts)
+	if err := getClusterScopedResources(s, "clusterversions", "config.openshift.io", nil); err != nil {
+		t.Fatalf("getClusterScopedResources: %v", err)
+	}
+	var out, errOut bytes.Buffer
+	if err := s.handleOutput(&out, &errOut); err != nil {
+		t.Fatalf("handleOutput: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "version-a") || !strings.Contains(got, "version-b") {
+		t.Fatalf("expected both items in output, got:\n%s", got)
+	}
+}
+
 func TestGetCmd_PropagatesErrorThroughCobra(t *testing.T) {
 	root := t.TempDir()
 	rdir := filepath.Join(root, "cluster-scoped-resources", "config.openshift.io")

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -265,18 +266,10 @@ items:
 	savedPath := vars.MustGatherRootPath
 	savedOutput := vars.OutputStringVar
 	savedNs := vars.Namespace
-	savedWide := vars.Wide
-	savedShowKind := vars.ShowKind
-	savedShowNs := vars.ShowNamespace
-	savedShowLabels := vars.ShowLabelsBoolVar
 	t.Cleanup(func() {
 		vars.MustGatherRootPath = savedPath
 		vars.OutputStringVar = savedOutput
 		vars.Namespace = savedNs
-		vars.Wide = savedWide
-		vars.ShowKind = savedShowKind
-		vars.ShowNamespace = savedShowNs
-		vars.ShowLabelsBoolVar = savedShowLabels
 		GetCmd.SetArgs(nil)
 		GetCmd.SetOut(nil)
 		GetCmd.SetErr(nil)
@@ -303,5 +296,89 @@ items:
 	}
 	if libOut.Len() == 0 {
 		t.Fatalf("expected non-empty output from fixture")
+	}
+}
+
+// TestRun_ConcurrentOptionsIsolation runs two goroutines calling Run with
+// different Options and checks each call sees only its own options. The
+// tablegenerator functions used to read vars globals, so concurrent calls
+// raced on fields like vars.ShowKind and vars.Namespace.
+func TestRun_ConcurrentOptionsIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Build a shared fixture with two namespaces and one pod in each.
+	root := t.TempDir()
+	for _, ns := range []string{"ns-a", "ns-b"} {
+		dir := filepath.Join(root, "namespaces", ns, "core")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		pods := []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: pod-` + ns + `
+    namespace: ` + ns + `
+  spec: {}
+  status: {}
+`)
+		if err := os.WriteFile(filepath.Join(dir, "pods.yaml"), pods, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	savedPath := vars.MustGatherRootPath
+	t.Cleanup(func() { vars.MustGatherRootPath = savedPath })
+	vars.MustGatherRootPath = root
+
+	const iterations = 50
+	type result struct {
+		out string
+		ns  string
+	}
+	results := make([]result, iterations*2)
+	var wg sync.WaitGroup
+	for i := range iterations {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			opts := newOptions()
+			opts.Namespace = "ns-a"
+			var out, errOut bytes.Buffer
+			if err := Run(&out, &errOut, opts, []string{"pods"}); err != nil {
+				t.Errorf("iteration %d ns-a: %v", i, err)
+				return
+			}
+			results[i*2] = result{out: out.String(), ns: "ns-a"}
+		}()
+		go func() {
+			defer wg.Done()
+			opts := newOptions()
+			opts.Namespace = "ns-b"
+			var out, errOut bytes.Buffer
+			if err := Run(&out, &errOut, opts, []string{"pods"}); err != nil {
+				t.Errorf("iteration %d ns-b: %v", i, err)
+				return
+			}
+			results[i*2+1] = result{out: out.String(), ns: "ns-b"}
+		}()
+		wg.Wait()
+	}
+
+	for i, r := range results {
+		if r.ns == "ns-a" && !strings.Contains(r.out, "pod-ns-a") {
+			t.Errorf("result %d (ns-a): expected pod-ns-a in output, got:\n%s", i, r.out)
+		}
+		if r.ns == "ns-a" && strings.Contains(r.out, "pod-ns-b") {
+			t.Errorf("result %d (ns-a): found pod-ns-b in ns-a output, got:\n%s", i, r.out)
+		}
+		if r.ns == "ns-b" && !strings.Contains(r.out, "pod-ns-b") {
+			t.Errorf("result %d (ns-b): expected pod-ns-b in output, got:\n%s", i, r.out)
+		}
+		if r.ns == "ns-b" && strings.Contains(r.out, "pod-ns-a") {
+			t.Errorf("result %d (ns-b): found pod-ns-a in ns-b output, got:\n%s", i, r.out)
+		}
 	}
 }

--- a/cmd/get/options.go
+++ b/cmd/get/options.go
@@ -18,18 +18,19 @@ package get
 // Options holds the configuration for a single get invocation. Fields are
 // populated from the cobra-bound flags before Run is invoked.
 type Options struct {
-	Namespace      string
-	Output         string
-	LabelSelector  string
-	NoHeaders      bool
-	AllNamespaces  bool
-	ShowLabels     bool
-	Wide           bool
-	ShowKind       bool
-	ShowNamespace  bool
-	SortBy         string
-	SingleResource bool
-	GetArgs        map[string]map[string]struct{}
+	Namespace         string
+	Output            string
+	LabelSelector     string
+	NoHeaders         bool
+	AllNamespaces     bool
+	ShowLabels        bool
+	Wide              bool
+	ShowKind          bool
+	ShowNamespace     bool
+	SortBy            string
+	SingleResource    bool
+	ShowManagedFields bool
+	GetArgs           map[string]map[string]struct{}
 }
 
 func newOptions() Options {

--- a/pkg/tablegenerator/tablegenerator.go
+++ b/pkg/tablegenerator/tablegenerator.go
@@ -9,26 +9,37 @@ import (
 	"strings"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/printers"
 
-	//"github.com/gmeghnag/vars/types"
-
 	helpers "github.com/gmeghnag/omc/cmd/helpers"
 	"github.com/gmeghnag/omc/vars"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-func CustomColumnsTable(unstruct *unstructured.Unstructured) (*metav1.Table, error) {
+// DisplayConfig carries the per-invocation display settings that the table
+// generator needs. Passing it as a value rather than reading from vars makes
+// the functions safe to call concurrently from multiple goroutines.
+type DisplayConfig struct {
+	Wide           bool
+	ShowKind       bool
+	ShowNamespace  bool
+	ShowLabels     bool
+	Namespace      string
+	Output         string
+	TableGenerator *printers.HumanReadableGenerator
+	AliasToCrd     map[string]apiextensionsv1.CustomResourceDefinition
+}
+
+func CustomColumnsTable(unstruct *unstructured.Unstructured, cfg DisplayConfig) (*metav1.Table, error) {
 	// Matches .metadata.name and metadata.name formats
 	format := regexp.MustCompile(`^\.?([^{}]+)$`)
 	fieldSelectors := map[string]string{}
 	prefix := "custom-columns="
 	table := &metav1.Table{}
-	args := vars.OutputStringVar[len(prefix):]
+	args := cfg.Output[len(prefix):]
 	fields := strings.Split(args, ",")
 
 	for _, field := range fields {
@@ -55,11 +66,11 @@ func CustomColumnsTable(unstruct *unstructured.Unstructured) (*metav1.Table, err
 	return table, nil
 }
 
-func InternalResourceTable(runtimeObject runtime.Object, unstruct *unstructured.Unstructured) (*metav1.Table, error) {
+func InternalResourceTable(runtimeObject runtime.Object, unstruct *unstructured.Unstructured, cfg DisplayConfig) (*metav1.Table, error) {
 	resourceKind := strings.ToLower(unstruct.GetKind())
-	table, err := vars.TableGenerator.GenerateTable(runtimeObject, printers.GenerateOptions{Wide: vars.Wide, NoHeaders: false})
+	table, err := cfg.TableGenerator.GenerateTable(runtimeObject, printers.GenerateOptions{Wide: cfg.Wide, NoHeaders: false})
 	if err != nil {
-		return InternalUnstructuredApiResource(*unstruct)
+		return InternalUnstructuredApiResource(*unstruct, cfg)
 	}
 	for i, column := range table.ColumnDefinitions {
 		if column.Name == "Age" {
@@ -83,7 +94,7 @@ func InternalResourceTable(runtimeObject runtime.Object, unstruct *unstructured.
 		}
 	}
 	if table.ColumnDefinitions[0].Name == "Name" {
-		if vars.ShowKind {
+		if cfg.ShowKind {
 			table.Rows[0].Cells[0] = resourceKind + "/" + unstruct.GetName()
 		} else {
 			table.Rows[0].Cells[0] = unstruct.GetName()
@@ -113,11 +124,11 @@ func InternalResourceTable(runtimeObject runtime.Object, unstruct *unstructured.
 		table.Rows[0].Cells[0] = lastSeen
 	}
 
-	if vars.ShowNamespace {
+	if cfg.ShowNamespace {
 		table.ColumnDefinitions = append([]metav1.TableColumnDefinition{{Format: "string", Name: "Namespace"}}, table.ColumnDefinitions...)
 		table.Rows[0].Cells = append([]interface{}{unstruct.GetNamespace()}, table.Rows[0].Cells...)
 	}
-	if vars.ShowLabelsBoolVar {
+	if cfg.ShowLabels {
 		table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Format: "string", Name: "Labels"})
 		labels := helpers.ExtractLabels(unstruct.GetLabels())
 		table.Rows[0].Cells = append(table.Rows[0].Cells, labels)
@@ -125,16 +136,16 @@ func InternalResourceTable(runtimeObject runtime.Object, unstruct *unstructured.
 	return table, err
 }
 
-func InternalUnstructuredApiResource(unstruct unstructured.Unstructured) (*metav1.Table, error) {
+func InternalUnstructuredApiResource(unstruct unstructured.Unstructured, cfg DisplayConfig) (*metav1.Table, error) {
 	resourceKind := strings.ToLower(unstruct.GetKind())
 	table := &metav1.Table{}
-	if vars.ShowNamespace && unstruct.GetNamespace() != "" {
+	if cfg.ShowNamespace && unstruct.GetNamespace() != "" {
 		table.ColumnDefinitions = []metav1.TableColumnDefinition{
 			{Name: "Namespace", Type: "string", Format: "name"},
 			{Name: "Name", Type: "string", Format: "string"},
 			{Name: "Created At", Type: "date"},
 		}
-		if vars.ShowKind || vars.Namespace == "" {
+		if cfg.ShowKind || cfg.Namespace == "" {
 			table.Rows = []metav1.TableRow{{Cells: []interface{}{unstruct.GetNamespace(), resourceKind + "." + strings.Split(unstruct.GetAPIVersion(), "/")[0] + "/" + unstruct.GetName(), unstruct.GetCreationTimestamp().Time.UTC().Format("2006-01-02T15:04:05")}}}
 		} else {
 			table.Rows = []metav1.TableRow{{Cells: []interface{}{unstruct.GetNamespace(), unstruct.GetName(), unstruct.GetCreationTimestamp().Time.UTC().Format("2006-01-02T15:04:05")}}}
@@ -145,7 +156,7 @@ func InternalUnstructuredApiResource(unstruct unstructured.Unstructured) (*metav
 			{Name: "Name", Type: "string", Format: "name"},
 			{Name: "Created At", Type: "date"},
 		}
-		if vars.ShowKind || vars.Namespace == "" {
+		if cfg.ShowKind || cfg.Namespace == "" {
 			table.Rows = []metav1.TableRow{{Cells: []interface{}{resourceKind + "." + strings.Split(unstruct.GetAPIVersion(), "/")[0] + "/" + unstruct.GetName(), unstruct.GetCreationTimestamp().Time.UTC().Format("2006-01-02T15:04:05")}}}
 
 		} else {
@@ -156,18 +167,18 @@ func InternalUnstructuredApiResource(unstruct unstructured.Unstructured) (*metav
 	return table, nil
 }
 
-func GenerateCustomResourceTable(unstruct unstructured.Unstructured) (*metav1.Table, error) {
+func GenerateCustomResourceTable(unstruct unstructured.Unstructured, cfg DisplayConfig) (*metav1.Table, error) {
 	resourceKind := strings.ToLower(unstruct.GetKind())
 	table := &metav1.Table{}
-	vars.CRD = nil
-	crd, ok := vars.AliasToCrd[resourceKind+"."+strings.Split(unstruct.GetAPIVersion(), "/")[0]]
-	if ok {
-		vars.CRD = &apiextensionsv1.CustomResourceDefinition{Spec: crd.Spec}
+	var crdSpec *apiextensionsv1.CustomResourceDefinitionSpec
+	if crd, ok := cfg.AliasToCrd[resourceKind+"."+strings.Split(unstruct.GetAPIVersion(), "/")[0]]; ok {
+		spec := crd.Spec
+		crdSpec = &spec
 	}
 
 	cells := []interface{}{}
-	if vars.ShowKind == true {
-		if vars.ShowNamespace && unstruct.GetNamespace() != "" {
+	if cfg.ShowKind {
+		if cfg.ShowNamespace && unstruct.GetNamespace() != "" {
 			table.ColumnDefinitions = []metav1.TableColumnDefinition{{Name: "Namespace", Format: "string"}, {Name: "Name", Format: "name"}}
 			cells = []interface{}{unstruct.GetNamespace(), resourceKind + "/" + unstruct.GetName()}
 		} else {
@@ -175,7 +186,7 @@ func GenerateCustomResourceTable(unstruct unstructured.Unstructured) (*metav1.Ta
 			cells = []interface{}{resourceKind + "/" + unstruct.GetName()}
 		}
 	} else {
-		if vars.ShowNamespace && unstruct.GetNamespace() != "" {
+		if cfg.ShowNamespace && unstruct.GetNamespace() != "" {
 			table.ColumnDefinitions = []metav1.TableColumnDefinition{{Name: "Namespace", Format: "string"}, {Name: "Name", Format: "name"}}
 			cells = []interface{}{unstruct.GetNamespace(), unstruct.GetName()}
 		} else {
@@ -183,35 +194,40 @@ func GenerateCustomResourceTable(unstruct unstructured.Unstructured) (*metav1.Ta
 			cells = []interface{}{unstruct.GetName()}
 		}
 	}
-	for i, column := range vars.CRD.Spec.Versions {
-		if (vars.CRD.Spec.Group + "/" + column.Name) == unstruct.GetAPIVersion() {
-			if len(vars.CRD.Spec.Versions[i].AdditionalPrinterColumns) > 0 {
-				for _, column := range vars.CRD.Spec.Versions[i].AdditionalPrinterColumns {
-					table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Name: column.Name, Format: "string"})
-					if column.Name == "Age" {
-						cells = append(cells, helpers.TranslateTimestamp(unstruct.GetCreationTimestamp()))
-						continue
+	if crdSpec != nil {
+		for i, column := range crdSpec.Versions {
+			if (crdSpec.Group + "/" + column.Name) == unstruct.GetAPIVersion() {
+				if len(crdSpec.Versions[i].AdditionalPrinterColumns) > 0 {
+					for _, column := range crdSpec.Versions[i].AdditionalPrinterColumns {
+						table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Name: column.Name, Format: "string"})
+						if column.Name == "Age" {
+							cells = append(cells, helpers.TranslateTimestamp(unstruct.GetCreationTimestamp()))
+							continue
+						}
+						if column.Name == "Since" {
+							v := helpers.GetFromJsonPath(unstruct.Object, fmt.Sprintf("%s%s%s", "{", column.JSONPath, "}"))
+							parsedTime, _ := time.Parse(time.RFC3339, v)
+							metav1Time := metav1.Time{Time: parsedTime}
+							v = helpers.TranslateTimestamp(metav1Time)
+							cells = append(cells, v)
+						} else {
+							v := helpers.GetFromJsonPath(unstruct.Object, fmt.Sprintf("%s%s%s", "{", column.JSONPath, "}"))
+							cells = append(cells, v)
+						}
 					}
-					if column.Name == "Since" {
-						v := helpers.GetFromJsonPath(unstruct.Object, fmt.Sprintf("%s%s%s", "{", column.JSONPath, "}"))
-						parsedTime, _ := time.Parse(time.RFC3339, v)
-						metav1Time := metav1.Time{Time: parsedTime}
-						v = helpers.TranslateTimestamp(metav1Time)
-						cells = append(cells, v)
-					} else {
-						v := helpers.GetFromJsonPath(unstruct.Object, fmt.Sprintf("%s%s%s", "{", column.JSONPath, "}"))
-						cells = append(cells, v)
-					}
+				} else {
+					table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Name: "Age", Format: "string"})
+					cells = append(cells, helpers.TranslateTimestamp(unstruct.GetCreationTimestamp()))
 				}
-			} else {
-				table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Name: "Age", Format: "string"})
-				cells = append(cells, helpers.TranslateTimestamp(unstruct.GetCreationTimestamp()))
+				break
 			}
-			break
 		}
+	} else {
+		table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Name: "Age", Format: "string"})
+		cells = append(cells, helpers.TranslateTimestamp(unstruct.GetCreationTimestamp()))
 	}
 	table.Rows = []metav1.TableRow{{Cells: cells}}
-	if vars.ShowLabelsBoolVar {
+	if cfg.ShowLabels {
 		table.ColumnDefinitions = append(table.ColumnDefinitions, metav1.TableColumnDefinition{Format: "string", Name: "Labels"})
 		labels := helpers.ExtractLabels(unstruct.GetLabels())
 		table.Rows[0].Cells = append(table.Rows[0].Cells, labels)

--- a/vars/vars.go
+++ b/vars/vars.go
@@ -7,13 +7,12 @@ import (
 )
 
 var CfgFile, Namespace, MustGatherRootPath, OutputStringVar, Id, Container, OMCVersionHash, OMCVersionTag, DiffCmd, DefaultProject, ForResource string
-var AllNamespaceBoolVar, ShowLabelsBoolVar, UseLocalCRDs, Wide, ShowKind, ShowNamespace, ShowManagedFields bool
+var AllNamespaceBoolVar, UseLocalCRDs bool
 
 var EventTypes []string
 var AliasToCrd map[string]apiextensionsv1.CustomResourceDefinition
 var ArgPresent map[string]bool
 var KnownResources map[string]map[string]interface{}
 var TableGenerator *printers.HumanReadableGenerator
-var CRD *apiextensionsv1.CustomResourceDefinition
 
 var Schema *runtime.Scheme


### PR DESCRIPTION
The two changes stacked in this MR:
- table generator now takes a DisplayConfig value instead of reading vars globals, so its functions are safe to call concurrently
- get does not fail anymore when a kind: List is passed instead of an Item